### PR TITLE
Add permission checks and graceful shutdown handling

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -414,12 +414,36 @@ impl MusicBotClient {
     pub async fn start(&mut self) -> Result<(), MusicBotError> {
         tracing::info!("Starting bot client");
 
+        let shard_manager = self.serenity_client.shard_manager.clone();
+        tokio::spawn(async move {
+            wait_for_signal().await;
+            tracing::info!("Shutdown signal received, disconnecting bot...");
+            shard_manager.shutdown_all().await;
+        });
+
         self.serenity_client.start().await
             .map_err(|e| {
                 tracing::error!("Failed to start server: {:?}", e);
                 MusicBotError::InternalError(e.to_string())
             })
     }
+}
+
+#[cfg(unix)]
+async fn wait_for_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate()).expect("Failed to listen for SIGTERM");
+    let mut sigint  = signal(SignalKind::interrupt()).expect("Failed to listen for SIGINT");
+    tokio::select! {
+        _ = sigterm.recv() => tracing::info!("Received SIGTERM"),
+        _ = sigint.recv()  => tracing::info!("Received SIGINT"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_signal() {
+    tokio::signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
+    tracing::info!("Received Ctrl+C");
 }
 
 async fn table_exists(database: &Arc<Database>, name: &str) -> Result<bool, MusicBotError> {

--- a/src/commands/music/cmd_history.rs
+++ b/src/commands/music/cmd_history.rs
@@ -5,7 +5,7 @@ use crate::player::player::{Player, Track};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage, Message};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 use tokio::sync::RwLockWriteGuard;
 
@@ -56,6 +56,7 @@ pub async fn history(ctx: Context<'_>) -> Result<(), MusicBotError> {
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
     let deadline = Instant::now() + Duration::from_secs(60 * 2);
+    let mut cooldowns: HashMap<serenity::all::UserId, Instant> = HashMap::new();
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
@@ -75,11 +76,20 @@ pub async fn history(ctx: Context<'_>) -> Result<(), MusicBotError> {
         match interaction {
             Some(interaction) => {
                 if interaction.user.id != ctx.author().id {
-                    interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
-                        CreateInteractionResponseMessage::new()
-                            .content("Only the person who ran this command can select a track.")
-                            .ephemeral(true)
-                    )).await.ok();
+                    let now = Instant::now();
+                    let on_cooldown = cooldowns.get(&interaction.user.id)
+                        .map(|&last| now.duration_since(last) < Duration::from_secs(5))
+                        .unwrap_or(false);
+                    if on_cooldown {
+                        interaction.defer(ctx.http()).await.ok();
+                    } else {
+                        cooldowns.insert(interaction.user.id, now);
+                        interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content("Only the person who ran this command can select a track.")
+                                .ephemeral(true)
+                        )).await.ok();
+                    }
                     continue;
                 }
 

--- a/src/commands/music/cmd_history.rs
+++ b/src/commands/music/cmd_history.rs
@@ -4,9 +4,9 @@ use crate::embeds::player_embed::PlayerEmbed;
 use crate::player::player::{Player, Track};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
-use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, Message};
+use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage, Message};
 use std::collections::VecDeque;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLockWriteGuard;
 
 /// Show the last 10 played tracks and optionally replay one.
@@ -55,35 +55,58 @@ pub async fn history(ctx: Context<'_>) -> Result<(), MusicBotError> {
     let message: Message = reply_handle.into_message().await
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
-    let interaction = message
-        .await_component_interaction(ctx.serenity_context().shard.clone())
-        .author_id(ctx.author().id)
-        .timeout(Duration::from_secs(60 * 2));
-
-    match interaction.await {
-        Some(interaction) => {
-            interaction.defer(ctx.http()).await?;
+    let deadline = Instant::now() + Duration::from_secs(60 * 2);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             message.delete(ctx.http()).await?;
-
-            let track_index: usize = interaction.data.custom_id
-                .strip_prefix("history_")
-                .and_then(|s| s.parse().ok())
-                .unwrap();
-            let track: Track = tracks_rev[track_index].clone();
-
-            let mut player: RwLockWriteGuard<Player> = ctx.data().player.write().await;
-            player.add_track_to_queue(ctx, track, false).await?;
-            drop(player);
-
-            channel_service::join_user_channel(ctx).await?;
-        }
-        None => {
-            message.delete(ctx.http()).await?;
-
             PlayerEmbed::SearchExpired
                 .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
+            return Ok(());
+        }
+
+        let interaction = message
+            .await_component_interaction(ctx.serenity_context().shard.clone())
+            .timeout(remaining)
+            .await;
+
+        match interaction {
+            Some(interaction) => {
+                if interaction.user.id != ctx.author().id {
+                    interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("Only the person who ran this command can select a track.")
+                            .ephemeral(true)
+                    )).await.ok();
+                    continue;
+                }
+
+                interaction.defer(ctx.http()).await?;
+                message.delete(ctx.http()).await?;
+
+                let track_index: usize = interaction.data.custom_id
+                    .strip_prefix("history_")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap();
+                let track: Track = tracks_rev[track_index].clone();
+
+                let mut player: RwLockWriteGuard<Player> = ctx.data().player.write().await;
+                player.add_track_to_queue(ctx, track, false).await?;
+                drop(player);
+
+                channel_service::join_user_channel(ctx).await?;
+                break;
+            }
+            None => {
+                message.delete(ctx.http()).await?;
+                PlayerEmbed::SearchExpired
+                    .to_embed()
+                    .send_context(ctx, true, Some(15))
+                    .await?;
+                break;
+            }
         }
     }
 

--- a/src/commands/music/cmd_history.rs
+++ b/src/commands/music/cmd_history.rs
@@ -57,6 +57,7 @@ pub async fn history(ctx: Context<'_>) -> Result<(), MusicBotError> {
 
     let interaction = message
         .await_component_interaction(ctx.serenity_context().shard.clone())
+        .author_id(ctx.author().id)
         .timeout(Duration::from_secs(60 * 2));
 
     match interaction.await {

--- a/src/commands/music/cmd_local.rs
+++ b/src/commands/music/cmd_local.rs
@@ -8,6 +8,7 @@ use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use crate::service::local_service;
 use serenity::all::{Attachment, ButtonStyle, CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage, Message};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLockWriteGuard;
@@ -446,6 +447,7 @@ async fn show_picker(
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
     let deadline = Instant::now() + Duration::from_secs(60 * 2);
+    let mut cooldowns: HashMap<serenity::all::UserId, Instant> = HashMap::new();
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
@@ -465,11 +467,20 @@ async fn show_picker(
         match interaction {
             Some(interaction) => {
                 if interaction.user.id != ctx.author().id {
-                    interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
-                        CreateInteractionResponseMessage::new()
-                            .content("Only the person who ran this command can make a selection.")
-                            .ephemeral(true)
-                    )).await.ok();
+                    let now = Instant::now();
+                    let on_cooldown = cooldowns.get(&interaction.user.id)
+                        .map(|&last| now.duration_since(last) < Duration::from_secs(5))
+                        .unwrap_or(false);
+                    if on_cooldown {
+                        interaction.defer(ctx.http()).await.ok();
+                    } else {
+                        cooldowns.insert(interaction.user.id, now);
+                        interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content("Only the person who ran this command can make a selection.")
+                                .ephemeral(true)
+                        )).await.ok();
+                    }
                     continue;
                 }
 

--- a/src/commands/music/cmd_local.rs
+++ b/src/commands/music/cmd_local.rs
@@ -447,6 +447,7 @@ async fn show_picker(
 
     let interaction = message
         .await_component_interaction(ctx.serenity_context().shard.clone())
+        .author_id(ctx.author().id)
         .timeout(Duration::from_secs(60 * 2))
         .await;
 

--- a/src/commands/music/cmd_local.rs
+++ b/src/commands/music/cmd_local.rs
@@ -7,9 +7,9 @@ use crate::player::player::{Player, Track};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use crate::service::local_service;
-use serenity::all::{Attachment, ButtonStyle, CreateActionRow, CreateButton, Message};
+use serenity::all::{Attachment, ButtonStyle, CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage, Message};
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLockWriteGuard;
 
 const PICKER_LIMIT: usize = 25;
@@ -445,40 +445,61 @@ async fn show_picker(
     let message: Message = reply_handle.into_message().await
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
-    let interaction = message
-        .await_component_interaction(ctx.serenity_context().shard.clone())
-        .author_id(ctx.author().id)
-        .timeout(Duration::from_secs(60 * 2))
-        .await;
-
-    match interaction {
-        Some(interaction) => {
-            interaction.defer(ctx.http()).await?;
-            message.delete(ctx.http()).await?;
-
-            if interaction.data.custom_id == format!("{id_prefix}_cancel") {
-                PlayerEmbed::SearchCancelled
-                    .to_embed()
-                    .send_context(ctx, true, Some(15))
-                    .await?;
-                return Ok(None);
-            }
-
-            let prefix = format!("{id_prefix}_");
-            let index: usize = interaction.data.custom_id
-                .strip_prefix(&prefix)
-                .and_then(|s| s.parse().ok())
-                .ok_or_else(|| MusicBotError::InternalError("Bad picker id".into()))?;
-
-            Ok(files.get(index).cloned())
-        }
-        None => {
+    let deadline = Instant::now() + Duration::from_secs(60 * 2);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             message.delete(ctx.http()).await?;
             PlayerEmbed::SearchExpired
                 .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
-            Ok(None)
+            return Ok(None);
+        }
+
+        let interaction = message
+            .await_component_interaction(ctx.serenity_context().shard.clone())
+            .timeout(remaining)
+            .await;
+
+        match interaction {
+            Some(interaction) => {
+                if interaction.user.id != ctx.author().id {
+                    interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("Only the person who ran this command can make a selection.")
+                            .ephemeral(true)
+                    )).await.ok();
+                    continue;
+                }
+
+                interaction.defer(ctx.http()).await?;
+                message.delete(ctx.http()).await?;
+
+                if interaction.data.custom_id == format!("{id_prefix}_cancel") {
+                    PlayerEmbed::SearchCancelled
+                        .to_embed()
+                        .send_context(ctx, true, Some(15))
+                        .await?;
+                    return Ok(None);
+                }
+
+                let prefix = format!("{id_prefix}_");
+                let index: usize = interaction.data.custom_id
+                    .strip_prefix(&prefix)
+                    .and_then(|s| s.parse().ok())
+                    .ok_or_else(|| MusicBotError::InternalError("Bad picker id".into()))?;
+
+                return Ok(files.get(index).cloned());
+            }
+            None => {
+                message.delete(ctx.http()).await?;
+                PlayerEmbed::SearchExpired
+                    .to_embed()
+                    .send_context(ctx, true, Some(15))
+                    .await?;
+                return Ok(None);
+            }
         }
     }
 }

--- a/src/commands/music/cmd_play.rs
+++ b/src/commands/music/cmd_play.rs
@@ -7,9 +7,9 @@ use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use crate::sources::spotify::spotify_client::{SpotifyClient, SpotifyError, SpotifySearchResult};
 use crate::sources::youtube::youtube_client::{SearchError, YouTubeSearchResult, YoutubeClient};
-use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, Message};
+use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage, Message};
 use std::convert::Into;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLockWriteGuard;
 
 const YOUTUBE_VIDEO_URL: &str = "https://www.youtube.com/watch?v=";
@@ -132,59 +132,80 @@ async fn do_play(ctx: Context<'_>, track_source: String, top: bool) -> Result<()
             let message: Message = reply_handle.into_message().await
                 .map_err(|error| MusicBotError::InternalError(error.to_string()))?;
 
-            let interaction = message
-                .await_component_interaction(ctx.serenity_context().shard.clone())
-                .author_id(ctx.author().id)
-                .timeout(Duration::from_secs(60 * 2));
-
-            match interaction.await {
-                Some(interaction) => {
-                    interaction.defer(ctx.http()).await?;
+            let deadline = Instant::now() + Duration::from_secs(60 * 2);
+            loop {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
                     message.delete(ctx.http()).await?;
-
-                    if interaction.data.custom_id == "track_cancel" {
-                        PlayerEmbed::SearchCancelled
-                            .to_embed()
-                            .send_context(ctx, true, Some(30))
-                            .await?;
-                        return Ok(());
-                    }
-
-                    let track_index: usize = interaction.data.custom_id
-                        .strip_prefix("track_")
-                        .and_then(|s| s.parse().ok())
-                        .unwrap();
-                    let mut track: Track = tracks.swap_remove(track_index);
-                    track.added_by = ctx.author().name.clone();
-
-                    let mut player: RwLockWriteGuard<Player> = ctx.data().player.write().await;
-
-                    if player.is_playing {
-                        QueueEmbed::TrackAdded(&track)
-                            .to_embed()
-                            .send_context(ctx, true, Some(30))
-                            .await?;
-                    }
-
-                    if let Err(error) = player.add_track_to_queue(ctx, track, top).await {
-                        drop(player);
-                        report_playback_error(ctx, error).await?;
-                        return Ok(());
-                    }
-                    drop(player);
-                    channel_service::join_user_channel(ctx).await?;
-                },
-                None => {
-                    message.delete(ctx.http()).await?;
-
                     PlayerEmbed::SearchExpired
                         .to_embed()
                         .send_context(ctx, true, Some(30))
                         .await?;
-
                     return Ok(());
                 }
-            };
+
+                let interaction = message
+                    .await_component_interaction(ctx.serenity_context().shard.clone())
+                    .timeout(remaining)
+                    .await;
+
+                match interaction {
+                    Some(interaction) => {
+                        if interaction.user.id != ctx.author().id {
+                            interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
+                                CreateInteractionResponseMessage::new()
+                                    .content("Only the person who ran this command can select a track.")
+                                    .ephemeral(true)
+                            )).await.ok();
+                            continue;
+                        }
+
+                        interaction.defer(ctx.http()).await?;
+                        message.delete(ctx.http()).await?;
+
+                        if interaction.data.custom_id == "track_cancel" {
+                            PlayerEmbed::SearchCancelled
+                                .to_embed()
+                                .send_context(ctx, true, Some(30))
+                                .await?;
+                            return Ok(());
+                        }
+
+                        let track_index: usize = interaction.data.custom_id
+                            .strip_prefix("track_")
+                            .and_then(|s| s.parse().ok())
+                            .unwrap();
+                        let mut track: Track = tracks.swap_remove(track_index);
+                        track.added_by = ctx.author().name.clone();
+
+                        let mut player: RwLockWriteGuard<Player> = ctx.data().player.write().await;
+
+                        if player.is_playing {
+                            QueueEmbed::TrackAdded(&track)
+                                .to_embed()
+                                .send_context(ctx, true, Some(30))
+                                .await?;
+                        }
+
+                        if let Err(error) = player.add_track_to_queue(ctx, track, top).await {
+                            drop(player);
+                            report_playback_error(ctx, error).await?;
+                            return Ok(());
+                        }
+                        drop(player);
+                        channel_service::join_user_channel(ctx).await?;
+                        break;
+                    }
+                    None => {
+                        message.delete(ctx.http()).await?;
+                        PlayerEmbed::SearchExpired
+                            .to_embed()
+                            .send_context(ctx, true, Some(30))
+                            .await?;
+                        return Ok(());
+                    }
+                }
+            }
         }
 
         Ok(YouTubeSearchResult::Playlist(mut playlist)) => {

--- a/src/commands/music/cmd_play.rs
+++ b/src/commands/music/cmd_play.rs
@@ -8,6 +8,7 @@ use crate::service::embed_service::SendEmbed;
 use crate::sources::spotify::spotify_client::{SpotifyClient, SpotifyError, SpotifySearchResult};
 use crate::sources::youtube::youtube_client::{SearchError, YouTubeSearchResult, YoutubeClient};
 use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage, Message};
+use std::collections::HashMap;
 use std::convert::Into;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLockWriteGuard;
@@ -133,6 +134,7 @@ async fn do_play(ctx: Context<'_>, track_source: String, top: bool) -> Result<()
                 .map_err(|error| MusicBotError::InternalError(error.to_string()))?;
 
             let deadline = Instant::now() + Duration::from_secs(60 * 2);
+            let mut cooldowns: HashMap<serenity::all::UserId, Instant> = HashMap::new();
             loop {
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
@@ -152,11 +154,20 @@ async fn do_play(ctx: Context<'_>, track_source: String, top: bool) -> Result<()
                 match interaction {
                     Some(interaction) => {
                         if interaction.user.id != ctx.author().id {
-                            interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
-                                CreateInteractionResponseMessage::new()
-                                    .content("Only the person who ran this command can select a track.")
-                                    .ephemeral(true)
-                            )).await.ok();
+                            let now = Instant::now();
+                            let on_cooldown = cooldowns.get(&interaction.user.id)
+                                .map(|&last| now.duration_since(last) < Duration::from_secs(5))
+                                .unwrap_or(false);
+                            if on_cooldown {
+                                interaction.defer(ctx.http()).await.ok();
+                            } else {
+                                cooldowns.insert(interaction.user.id, now);
+                                interaction.create_response(ctx.http(), CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content("Only the person who ran this command can select a track.")
+                                        .ephemeral(true)
+                                )).await.ok();
+                            }
                             continue;
                         }
 

--- a/src/commands/music/cmd_play.rs
+++ b/src/commands/music/cmd_play.rs
@@ -134,6 +134,7 @@ async fn do_play(ctx: Context<'_>, track_source: String, top: bool) -> Result<()
 
             let interaction = message
                 .await_component_interaction(ctx.serenity_context().shard.clone())
+                .author_id(ctx.author().id)
                 .timeout(Duration::from_secs(60 * 2));
 
             match interaction.await {

--- a/src/commands/music/cmd_queue.rs
+++ b/src/commands/music/cmd_queue.rs
@@ -4,7 +4,8 @@ use crate::embeds::queue_embed::QueueEmbed;
 use crate::player::player::Player;
 use crate::service::embed_service::SendEmbed;
 use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, EditMessage};
-use std::time::Duration;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLockReadGuard;
 
 const ITEMS_PER_PAGE: usize = 10;
@@ -81,6 +82,7 @@ pub async fn queue(ctx: Context<'_>, page: Option<usize>) -> Result<(), MusicBot
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
     let http = ctx.serenity_context().http.clone();
+    let mut cooldowns: HashMap<serenity::all::UserId, Instant> = HashMap::new();
 
     loop {
         let interaction = message
@@ -91,11 +93,20 @@ pub async fn queue(ctx: Context<'_>, page: Option<usize>) -> Result<(), MusicBot
         match interaction {
             Some(interaction) => {
                 if interaction.user.id != ctx.author().id {
-                    interaction.create_response(&http, CreateInteractionResponse::Message(
-                        CreateInteractionResponseMessage::new()
-                            .content("Only the person who ran this command can navigate the queue.")
-                            .ephemeral(true)
-                    )).await.ok();
+                    let now = Instant::now();
+                    let on_cooldown = cooldowns.get(&interaction.user.id)
+                        .map(|&last| now.duration_since(last) < Duration::from_secs(5))
+                        .unwrap_or(false);
+                    if on_cooldown {
+                        interaction.defer(&http).await.ok();
+                    } else {
+                        cooldowns.insert(interaction.user.id, now);
+                        interaction.create_response(&http, CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content("Only the person who ran this command can navigate the queue.")
+                                .ephemeral(true)
+                        )).await.ok();
+                    }
                     continue;
                 }
 

--- a/src/commands/music/cmd_queue.rs
+++ b/src/commands/music/cmd_queue.rs
@@ -85,6 +85,7 @@ pub async fn queue(ctx: Context<'_>, page: Option<usize>) -> Result<(), MusicBot
     loop {
         let interaction = message
             .await_component_interaction(ctx.serenity_context().shard.clone())
+            .author_id(ctx.author().id)
             .timeout(Duration::from_secs(60))
             .await;
 

--- a/src/commands/music/cmd_queue.rs
+++ b/src/commands/music/cmd_queue.rs
@@ -3,7 +3,7 @@ use crate::embeds::player_embed::PlayerEmbed;
 use crate::embeds::queue_embed::QueueEmbed;
 use crate::player::player::Player;
 use crate::service::embed_service::SendEmbed;
-use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateEmbed, EditMessage};
+use serenity::all::{ButtonStyle, CreateActionRow, CreateButton, CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, EditMessage};
 use std::time::Duration;
 use tokio::sync::RwLockReadGuard;
 
@@ -85,12 +85,20 @@ pub async fn queue(ctx: Context<'_>, page: Option<usize>) -> Result<(), MusicBot
     loop {
         let interaction = message
             .await_component_interaction(ctx.serenity_context().shard.clone())
-            .author_id(ctx.author().id)
             .timeout(Duration::from_secs(60))
             .await;
 
         match interaction {
             Some(interaction) => {
+                if interaction.user.id != ctx.author().id {
+                    interaction.create_response(&http, CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("Only the person who ran this command can navigate the queue.")
+                            .ephemeral(true)
+                    )).await.ok();
+                    continue;
+                }
+
                 interaction.defer(&http).await
                     .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,6 @@ async fn main() -> Result<(), MusicBotError> {
         .start()
         .await?;
 
-    // TODO: Properly handle shutdown logic
-
+    tracing::info!("Bot shut down cleanly.");
     Ok(())
 }


### PR DESCRIPTION
## Summary
This PR adds permission validation for button interactions and implements proper graceful shutdown handling for the bot. It ensures that only the user who initiated a command can interact with its buttons, and adds signal handling for clean bot termination.

## Key Changes

- **Permission Checks for Button Interactions**: Added user ID validation across multiple commands (`cmd_play`, `cmd_local`, `cmd_history`, `cmd_queue`) to ensure only the command initiator can interact with buttons. Non-authorized users receive an ephemeral error message with a 5-second cooldown to prevent spam.

- **Refactored Interaction Handling**: Converted from simple `await_component_interaction().await` patterns to loop-based implementations with explicit deadline tracking using `Instant`, allowing for:
  - Proper timeout management with remaining duration calculation
  - Continuous interaction handling until user selection or timeout
  - Cleaner separation of authorization logic

- **Graceful Shutdown**: Implemented signal handling in `bot.rs` that:
  - Listens for SIGTERM/SIGINT on Unix systems and Ctrl+C on Windows
  - Properly shuts down the shard manager when signals are received
  - Logs shutdown events for debugging

- **Import Updates**: Added necessary imports for `CreateInteractionResponse`, `CreateInteractionResponseMessage`, `HashMap`, and `Instant` across affected files.

## Implementation Details

- The permission check uses a cooldown mechanism (5-second window) to prevent spam from unauthorized users attempting to interact with buttons
- Unauthorized interactions either defer silently (if on cooldown) or send an ephemeral response explaining the restriction
- The deadline-based timeout approach allows for accurate remaining time calculation in loops, improving reliability over simple timeout durations
- Signal handling is platform-specific with conditional compilation for Unix vs. Windows systems

https://claude.ai/code/session_01BvUzD9a1JDu23PUp1qmPmb