### PR TITLE
Refactor documentation comments to use Rust doc style

### DIFF
--- a/src/commands/music/cmd_join.rs
+++ b/src/commands/music/cmd_join.rs
@@ -2,9 +2,7 @@ use crate::bot::{Context, MusicBotError};
 use crate::checks::channel_checks::check_author_in_voice_channel;
 use crate::service::channel_service;
 
-/**
-* Request the bot to join current user voice channel
-*/
+/// Join the voice channel you're currently in.
 #[poise::command(
     prefix_command, slash_command,
     check = "check_author_in_voice_channel",

--- a/src/commands/music/cmd_play.rs
+++ b/src/commands/music/cmd_play.rs
@@ -16,9 +16,7 @@ use tokio::sync::RwLockWriteGuard;
 const YOUTUBE_VIDEO_URL: &str = "https://www.youtube.com/watch?v=";
 const YOUTUBE_PLAYLIST_URL: &str = "https://www.youtube.com/playlist?list=";
 
-/**
-* Play a track or playlist from YouTube or Spotify
-*/
+/// Play a track or playlist from YouTube or Spotify.
 #[poise::command(
     prefix_command, slash_command,
     check = "check_author_in_same_voice_channel",
@@ -27,9 +25,7 @@ pub async fn play(ctx: Context<'_>, track_source: Vec<String>) -> Result<(), Mus
     do_play(ctx, track_source.join(" "), false).await
 }
 
-/**
-* Play a track or playlist immediately by inserting it at the front of the queue
-*/
+/// Play a track or playlist immediately by inserting it at the front of the queue.
 #[poise::command(
     prefix_command, slash_command,
     rename = "playtop",

--- a/src/commands/music/cmd_playing.rs
+++ b/src/commands/music/cmd_playing.rs
@@ -4,9 +4,7 @@ use crate::player::player::Player;
 use crate::service::embed_service::SendEmbed;
 use tokio::sync::RwLockReadGuard;
 
-/**
-* Display the currently playing track
-*/
+/// Display the currently playing track.
 #[poise::command(
     prefix_command, slash_command,
 )]

--- a/src/commands/music/cmd_shuffle.rs
+++ b/src/commands/music/cmd_shuffle.rs
@@ -6,9 +6,7 @@ use crate::player::player::Player;
 use crate::service::embed_service::SendEmbed;
 use tokio::sync::RwLockWriteGuard;
 
-/**
-* Shuffle the current queue
-*/
+/// Shuffle the current queue.
 #[poise::command(
     prefix_command, slash_command,
     check = "check_author_in_same_voice_channel",

--- a/src/commands/music/cmd_skip.rs
+++ b/src/commands/music/cmd_skip.rs
@@ -6,9 +6,7 @@ use crate::player::player::Player;
 use crate::service::embed_service::SendEmbed;
 use tokio::sync::RwLockWriteGuard;
 
-/**
-* Skip the current track. With an empty queue this stops playback instead of erroring.
-*/
+/// Skip the current track. With an empty queue this stops playback instead of erroring.
 #[poise::command(
     prefix_command, slash_command,
     check = "check_author_in_same_voice_channel",

--- a/src/commands/music/cmd_stop.rs
+++ b/src/commands/music/cmd_stop.rs
@@ -6,9 +6,7 @@ use crate::player::player::Player;
 use crate::service::embed_service::SendEmbed;
 use tokio::sync::RwLockWriteGuard;
 
-/**
-* Stop the current playback
-*/
+/// Stop the current playback.
 #[poise::command(
     prefix_command, slash_command,
     check = "check_author_in_same_voice_channel",

--- a/src/commands/music/cmd_vol.rs
+++ b/src/commands/music/cmd_vol.rs
@@ -10,9 +10,7 @@ use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 const DEFAULT_MAX_VOLUME: f32 = 100.0;
 const EXTENDED_MAX_VOLUME: f32 = 500.0;
 
-/**
-* Change the volume (1-100, or 1-500 with a trailing `!`).
-*/
+/// Change the volume (1-100, or 1-500 with a trailing `!`).
 #[poise::command(
     prefix_command, slash_command,
     check = "check_author_in_same_voice_channel",

--- a/src/commands/utility/cmd_uwu.rs
+++ b/src/commands/utility/cmd_uwu.rs
@@ -4,10 +4,8 @@ use serenity::all::{Color, CreateEmbed};
 use serenity::all::{Mention, Mentionable};
 use uwu_rs::uwuify;
 
-/**
-* Convert provided text to UwU format
-* -> This command requested by adaxiik
-*/
+/// Convert provided text to UwU format.
+// Requested by adaxiik.
 #[poise::command(
     prefix_command, slash_command,
 )]
@@ -21,10 +19,8 @@ pub async fn uwu(ctx: Context<'_>, text: Vec<String>) -> Result<(), MusicBotErro
     Ok(())
 }
 
-/**
-* Convert provided text to UwU format and send it as author
-* -> This command requested by adaxiik
-*/
+/// Convert provided text to UwU format and send it as the author.
+// Requested by adaxiik.
 #[poise::command(
     prefix_command, slash_command,
 )]

--- a/src/commands/utility/cmd_wakeup.rs
+++ b/src/commands/utility/cmd_wakeup.rs
@@ -5,9 +5,7 @@ use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use serenity::all::{Channel, ChannelId, GuildId, Member, Mention, Mentionable, PartialGuild, User};
 
-/**
-* Wake up a user in the same voice channel
-*/
+/// Wake up a user in the same voice channel.
 #[poise::command(
     slash_command,
     check = "check_author_in_same_voice_channel"
@@ -17,9 +15,7 @@ pub async fn wakeup(ctx: Context<'_>, target: Member, count: Option<usize>) -> R
     Ok(())
 }
 
-/**
-* Wake up a user in the same voice channel
-*/
+/// Wake up a user in the same voice channel.
 #[poise::command(
     context_menu_command = "WakeUp!",
     check = "check_author_in_same_voice_channel"


### PR DESCRIPTION
## Summary
Standardized all command documentation comments across the codebase to use Rust's idiomatic doc comment syntax (`///`) instead of block comments (`/** */`).

## Key Changes
- Converted multi-line block comment documentation (`/** */`) to single-line doc comments (`///`) for all command functions
- Updated comment formatting to follow Rust documentation conventions
- Improved readability and consistency with Rust best practices
- Minor wording improvements for clarity (e.g., "Wake up a user in the same voice channel" → "Wake up a user in the same voice channel.", "Request the bot to join current user voice channel" → "Join the voice channel you're currently in.")
- Moved secondary notes (e.g., "Requested by adaxiik") to regular comments (`//`) where applicable

## Files Modified
- `src/commands/utility/cmd_uwu.rs` - 2 command docs
- `src/commands/music/cmd_play.rs` - 2 command docs
- `src/commands/utility/cmd_wakeup.rs` - 2 command docs
- `src/commands/music/cmd_join.rs` - 1 command doc
- `src/commands/music/cmd_playing.rs` - 1 command doc
- `src/commands/music/cmd_shuffle.rs` - 1 command doc
- `src/commands/music/cmd_skip.rs` - 1 command doc
- `src/commands/music/cmd_stop.rs` - 1 command doc
- `src/commands/music/cmd_vol.rs` - 1 command doc

## Notable Details
This change improves code consistency and enables proper documentation generation through Rust's doc tools while maintaining all existing functionality.

https://claude.ai/code/session_013GJKHYmBQEP6va7kVTy273