### PR TITLE
Add context menu command for renaming users

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -131,6 +131,7 @@ impl MusicBotClient {
                     utility::cmd_wakeup::wakeup(),
                     utility::cmd_wakeup::wakeup_context(),
                     utility::cmd_rename::rename(),
+                    utility::cmd_rename::rename_context(),
                 ],
                 pre_command: |ctx| Box::pin(async move {
                     tracing::info!("CMD: {} is executing {} ({})", ctx.author().name, ctx.command().name, ctx.invocation_string());

--- a/src/commands/utility/cmd_rename.rs
+++ b/src/commands/utility/cmd_rename.rs
@@ -1,6 +1,15 @@
-use crate::bot::{Context, MusicBotError};
+use crate::bot::{Context, MusicBotData, MusicBotError};
 use crate::service::embed_service::SendEmbed;
 use serenity::all::{Color, CreateEmbed, EditMember, GuildId, Member, Mentionable, PartialGuild, User};
+
+#[derive(Debug, poise::Modal)]
+#[name = "Rename"]
+struct RenameModal {
+    #[name = "New nickname"]
+    #[placeholder = "leave empty to reset to original name"]
+    #[max_length = 32]
+    new_name: Option<String>,
+}
 
 /// Set a user's nickname. Caller's top role must be at-or-above the target's.
 #[poise::command(prefix_command, slash_command, guild_only)]
@@ -8,6 +17,29 @@ pub async fn rename(
     ctx: Context<'_>,
     user: User,
     #[rest] new_name: Option<String>,
+) -> Result<(), MusicBotError> {
+    do_rename(ctx, user, new_name).await
+}
+
+/// Rename a user via right-click → Apps → Rename. Opens a modal for the new nickname.
+#[poise::command(context_menu_command = "Rename", guild_only)]
+pub async fn rename_context(
+    ctx: poise::ApplicationContext<'_, MusicBotData, MusicBotError>,
+    user: User,
+) -> Result<(), MusicBotError> {
+    let data = match poise::Modal::execute(ctx).await? {
+        Some(d) => d,
+        None => return Ok(()),
+    };
+    let RenameModal { new_name } = data;
+
+    do_rename(poise::Context::Application(ctx), user, new_name).await
+}
+
+async fn do_rename(
+    ctx: Context<'_>,
+    user: User,
+    new_name: Option<String>,
 ) -> Result<(), MusicBotError> {
     let guild_id: GuildId = ctx.guild_id().ok_or_else(|| {
         MusicBotError::InternalError("Rename is only available in guilds".to_string())


### PR DESCRIPTION
## Summary
Added a new context menu command that allows users to rename other members via right-click → Apps → Rename, complementing the existing prefix/slash command functionality.

## Key Changes
- Created a `RenameModal` struct to handle user input for the new nickname via a modal dialog
- Extracted the core rename logic into a new `do_rename()` function to avoid code duplication
- Added `rename_context()` command handler that executes the modal and delegates to `do_rename()`
- Registered the new context menu command in the bot's command list
- Updated imports to include `MusicBotData` for the application context

## Implementation Details
- The modal includes a placeholder text suggesting users can leave it empty to reset to the original name
- The nickname field is limited to 32 characters (Discord's limit)
- The context menu command gracefully handles modal cancellation by returning `Ok(())`
- Both the original `rename()` command and new `rename_context()` command share the same validation and execution logic through `do_rename()`

https://claude.ai/code/session_01JFK1pRbSWLGhxDwST4XyGM