### PR TITLE
Add voice channel gathering and break timer features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "dotenv",
+ "emojis",
  "google-youtube3",
  "html-escape",
  "hyper 1.5.0",
@@ -31,6 +32,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "unicode-segmentation",
  "uwu-rs",
 ]
 
@@ -949,6 +951,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "emojis"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e1f1df1f181f2539bac8bf027d31ca5ffbf9e559e3f2d09413b9107b5c02f4"
+dependencies = [
+ "phf",
 ]
 
 [[package]]
@@ -2936,6 +2947,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4163,6 +4192,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skeptic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ uwu-rs = "1.0.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
+emojis = "0.6"
+unicode-segmentation = "1.11"

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -125,6 +125,8 @@ impl MusicBotClient {
                     music::cmd_normalize::normalize(),
                     utility::cmd_uwu::uwu(),
                     utility::cmd_uwu::uwu_me(),
+                    utility::cmd_gather::gather(),
+                    utility::cmd_break::r#break(),
                     utility::cmd_notify::notify(),
                     utility::cmd_notify::remind(),
                     utility::cmd_wakeup::wakeup(),

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,4 +1,5 @@
 use crate::commands;
+use crate::commands::utility::cmd_break::BreakState;
 use crate::commands::{music, reputation, utility};
 use crate::handlers::error_handler;
 use crate::player::notifier::{Notifier, NotifierError};
@@ -12,6 +13,7 @@ use serenity::all::{ChannelId, FullEvent, GatewayIntents, GuildId};
 use songbird::SerenityInit;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Pool, Sqlite};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{RwLock, RwLockWriteGuard};
 
@@ -22,6 +24,7 @@ pub struct MusicBotData {
     pub database_pool: Arc<Database>,
     pub player: Arc<RwLock<Player>>,
     pub notifier: Arc<RwLock<Notifier>>,
+    pub breaks: Arc<RwLock<HashMap<GuildId, Arc<BreakState>>>>,
 }
 
 pub type Database = Pool<Sqlite>;
@@ -286,6 +289,7 @@ impl MusicBotClient {
                         database_pool: database,
                         player: player_handle,
                         notifier: notifier_handle,
+                        breaks: Arc::new(RwLock::new(HashMap::new())),
                     })
                 })
             })

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -1,7 +1,7 @@
 use crate::bot::{Context, MusicBotError};
 use crate::checks::channel_checks::check_author_in_voice_channel;
 use crate::embeds::bot_embeds::BotEmbed;
-use crate::player::notifier::convert_time_offset_from_string;
+use crate::player::notifier::{convert_time_offset_from_string, get_current_time};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use crate::service::gather_service;
@@ -10,15 +10,58 @@ use serenity::all::{
     CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
     GuildId, Mentionable, Message, UserId,
 };
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use time::OffsetDateTime;
 
 const BTN_BREAK_CANCEL: &str = "break_cancel";
 const MAX_BREAK_DURATION: Duration = Duration::from_secs(60 * 60 * 4);
 const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Shared mutable state for the active break in a guild. Mutated by
+/// `/break extend` and read by the running `/break start` loop.
+pub struct BreakState {
+    pub author_id: UserId,
+    pub started_at_instant: Instant,
+    pub started_at_wall: OffsetDateTime,
+    pub original_duration: Duration,
+    pub extension: Mutex<Duration>,
+    pub author_mention: String,
+}
+
+impl BreakState {
+    fn total_duration(&self) -> Duration {
+        self.original_duration + *self.extension.lock().unwrap()
+    }
+
+    fn ends_at_instant(&self) -> Instant {
+        self.started_at_instant + self.total_duration()
+    }
+
+    fn ends_at_wall(&self) -> OffsetDateTime {
+        self.started_at_wall + self.total_duration()
+    }
+
+    fn extension_total(&self) -> Duration {
+        *self.extension.lock().unwrap()
+    }
+}
+
 /// Take a break — when the timer runs out, everyone in voice is auto-gathered.
+#[poise::command(
+    slash_command,
+    prefix_command,
+    subcommands("start", "extend"),
+    subcommand_required
+)]
+pub async fn r#break(_ctx: Context<'_>) -> Result<(), MusicBotError> {
+    Ok(())
+}
+
+/// Start a break of the given length. When the timer ends, a gathering is
+/// kicked off automatically.
 #[poise::command(slash_command, prefix_command, check = "check_author_in_voice_channel")]
-pub async fn r#break(
+pub async fn start(
     ctx: Context<'_>,
     #[description = "Break length, e.g. `5m`, `1h 30s`, `90s`."] time: String,
 ) -> Result<(), MusicBotError> {
@@ -30,7 +73,7 @@ pub async fn r#break(
                 .title("🚫  Break too long")
                 .description(format!(
                     "Maximum break length is {}.",
-                    format_hhmmss(MAX_BREAK_DURATION)
+                    humanize_duration(MAX_BREAK_DURATION)
                 ))
                 .send_context(ctx, true, Some(15))
                 .await?;
@@ -62,8 +105,20 @@ pub async fn r#break(
             }
         };
 
-    // Acknowledge the slash command — the timer message itself is a normal
-    // channel message so it can outlive the interaction token.
+    // Refuse to start a second break if one is already running in this guild.
+    {
+        let breaks = ctx.data().breaks.read().await;
+        if breaks.contains_key(&guild_id) {
+            CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Break already running")
+                .description("There's already an active break in this guild — extend it with `/break extend <time>` instead.")
+                .send_context(ctx, true, Some(15))
+                .await?;
+            return Ok(());
+        }
+    }
+
     if let poise::Context::Application(app_ctx) = ctx {
         let _ = app_ctx
             .interaction
@@ -79,9 +134,22 @@ pub async fn r#break(
     }
 
     let text_channel_id: ChannelId = ctx.channel_id();
-    let started_at = Instant::now();
-    let ends_at = started_at + duration;
     let author_mention = ctx.author().mention().to_string();
+
+    let state = Arc::new(BreakState {
+        author_id,
+        started_at_instant: Instant::now(),
+        started_at_wall: get_current_time(),
+        original_duration: duration,
+        extension: Mutex::new(Duration::ZERO),
+        author_mention: author_mention.clone(),
+    });
+
+    ctx.data()
+        .breaks
+        .write()
+        .await
+        .insert(guild_id, Arc::clone(&state));
 
     let mut msg: Message = text_channel_id
         .send_message(
@@ -91,13 +159,7 @@ pub async fn r#break(
                     "@here  ⏸️  {} started a break.",
                     author_mention
                 ))
-                .embed(build_break_embed(
-                    &author_mention,
-                    duration,
-                    Instant::now(),
-                    ends_at,
-                    None,
-                ))
+                .embed(build_break_embed(&state, None))
                 .components(break_buttons(false)),
         )
         .await
@@ -109,6 +171,7 @@ pub async fn r#break(
 
     loop {
         let now = Instant::now();
+        let ends_at = state.ends_at_instant();
         if now >= ends_at {
             break;
         }
@@ -152,13 +215,7 @@ pub async fn r#break(
             .edit(
                 ctx.http(),
                 EditMessage::new()
-                    .embed(build_break_embed(
-                        &author_mention,
-                        duration,
-                        Instant::now(),
-                        ends_at,
-                        None,
-                    ))
+                    .embed(build_break_embed(&state, None))
                     .components(break_buttons(false)),
             )
             .await;
@@ -174,16 +231,13 @@ pub async fn r#break(
         .edit(
             ctx.http(),
             EditMessage::new()
-                .embed(build_break_embed(
-                    &author_mention,
-                    duration,
-                    Instant::now(),
-                    ends_at,
-                    Some(footer),
-                ))
+                .embed(build_break_embed(&state, Some(footer)))
                 .components(Vec::new()),
         )
         .await;
+
+    // Drop the state before handing off to the gather flow.
+    ctx.data().breaks.write().await.remove(&guild_id);
 
     if cancelled {
         return Ok(());
@@ -201,9 +255,87 @@ pub async fn r#break(
     Ok(())
 }
 
+/// Extend the current break by the given amount of time.
+#[poise::command(slash_command, prefix_command)]
+pub async fn extend(
+    ctx: Context<'_>,
+    #[description = "Extra time to add, e.g. `5m`, `30s`, `1h 30s`."] time: String,
+) -> Result<(), MusicBotError> {
+    let extra = match parse_break_duration(&time) {
+        Some(d) if d > Duration::ZERO => d,
+        _ => {
+            CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Invalid extension")
+                .description("Use a relative duration like `5m`, `1h 30s`, or `90s`.")
+                .send_context(ctx, true, Some(15))
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let guild_id: GuildId = ctx.guild_id().ok_or(MusicBotError::NoGuildIdError)?;
+
+    let state = {
+        let breaks = ctx.data().breaks.read().await;
+        breaks.get(&guild_id).cloned()
+    };
+
+    let state = match state {
+        Some(s) => s,
+        None => {
+            CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  No active break")
+                .description("There's no break running right now. Start one with `/break start <time>`.")
+                .send_context(ctx, true, Some(15))
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let new_total = state.total_duration() + extra;
+    if new_total > MAX_BREAK_DURATION {
+        CreateEmbed::new()
+            .color(Color::DARK_RED)
+            .title("🚫  Extension would exceed cap")
+            .description(format!(
+                "Total break length would be `{}`, over the {} cap.",
+                humanize_duration(new_total),
+                humanize_duration(MAX_BREAK_DURATION)
+            ))
+            .send_context(ctx, true, Some(15))
+            .await?;
+        return Ok(());
+    }
+
+    {
+        let mut ext = state.extension.lock().unwrap();
+        *ext += extra;
+    }
+
+    let new_end = state.ends_at_wall();
+    CreateEmbed::new()
+        .color(Color::DARK_GREEN)
+        .title("⏱️  Break extended")
+        .description(format!(
+            "{} extended the break by **{}**.\n\n\
+             New total: **{}**\n\
+             Ends at: `{}`",
+            ctx.author().mention(),
+            humanize_duration(extra),
+            humanize_duration(state.total_duration()),
+            format_wall_clock(new_end),
+        ))
+        .send_context(ctx, false, None)
+        .await?;
+
+    Ok(())
+}
+
 fn parse_break_duration(text: &str) -> Option<Duration> {
     let target = convert_time_offset_from_string(text.trim().to_string())?;
-    let now = crate::player::notifier::get_current_time();
+    let now = get_current_time();
     let secs = (target - now).whole_seconds();
     if secs <= 0 {
         return None;
@@ -220,31 +352,46 @@ fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {
     .disabled(disabled)])]
 }
 
-fn build_break_embed(
-    author_mention: &str,
-    total: Duration,
-    now: Instant,
-    ends_at: Instant,
-    footer: Option<&str>,
-) -> CreateEmbed {
+fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {
+    let now = Instant::now();
+    let ends_at = state.ends_at_instant();
+    let total = state.total_duration();
     let remaining = ends_at.saturating_duration_since(now);
+    let extension = state.extension_total();
+
     let color = if footer.is_some() {
         Color::DARK_GREEN
     } else {
         Color::DARK_GOLD
     };
 
+    let mut description = format!(
+        "{} started a break of **{}**.\n\n\
+         Time remaining: **{}**\n\
+         Ends at: `{}`",
+        state.author_mention,
+        humanize_duration(state.original_duration),
+        humanize_duration(remaining),
+        format_wall_clock(state.ends_at_wall()),
+    );
+
+    if extension > Duration::ZERO {
+        description.push_str(&format!(
+            "\nExtended by: **{}** (total **{}**)",
+            humanize_duration(extension),
+            humanize_duration(total),
+        ));
+    }
+
+    description.push_str(
+        "\n\nWhen the timer ends, everyone still in voice will be gathered \
+         automatically — late arrivals will be tracked.",
+    );
+
     let mut builder = CreateEmbed::new()
         .color(color)
         .title("⏸️  Break in progress")
-        .description(format!(
-            "{} started a break of `{}`.\n\nTime remaining: **{}**\n\n\
-             When the timer ends, everyone still in voice will be gathered \
-             automatically — late arrivals will be tracked.",
-            author_mention,
-            format_hhmmss(total),
-            format_hhmmss(remaining),
-        ));
+        .description(description);
 
     if let Some(text) = footer {
         builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
@@ -253,14 +400,29 @@ fn build_break_embed(
     builder
 }
 
-fn format_hhmmss(d: Duration) -> String {
+fn humanize_duration(d: Duration) -> String {
     let total = d.as_secs();
+    if total == 0 {
+        return "0 seconds".to_string();
+    }
+
     let h = total / 3600;
     let m = (total % 3600) / 60;
     let s = total % 60;
+
+    let mut parts: Vec<String> = Vec::new();
     if h > 0 {
-        format!("{:02}:{:02}:{:02}", h, m, s)
-    } else {
-        format!("{:02}:{:02}", m, s)
+        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
     }
+    if m > 0 {
+        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
+    }
+    if s > 0 {
+        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
+    }
+    parts.join(" ")
+}
+
+fn format_wall_clock(t: OffsetDateTime) -> String {
+    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
 }

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -1,0 +1,257 @@
+use crate::bot::{Context, MusicBotError};
+use crate::checks::channel_checks::check_author_in_voice_channel;
+use crate::embeds::bot_embeds::BotEmbed;
+use crate::player::notifier::convert_time_offset_from_string;
+use crate::service::channel_service;
+use crate::service::embed_service::SendEmbed;
+use crate::service::gather_service;
+use serenity::all::{
+    ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
+    CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
+    GuildId, Message, UserId,
+};
+use std::time::{Duration, Instant};
+
+const BTN_BREAK_CANCEL: &str = "break_cancel";
+const MAX_BREAK_DURATION: Duration = Duration::from_secs(60 * 60 * 4);
+
+/// Take a break — when the timer runs out, everyone in voice is auto-gathered.
+#[poise::command(slash_command, prefix_command, check = "check_author_in_voice_channel")]
+pub async fn r#break(
+    ctx: Context<'_>,
+    #[description = "Break length, e.g. `5m`, `1h 30s`, `90s`."] time: String,
+) -> Result<(), MusicBotError> {
+    let duration = match parse_break_duration(&time) {
+        Some(d) if d > Duration::ZERO && d <= MAX_BREAK_DURATION => d,
+        Some(_) => {
+            CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Break too long")
+                .description(format!(
+                    "Maximum break length is {}.",
+                    format_hhmmss(MAX_BREAK_DURATION)
+                ))
+                .send_context(ctx, true, Some(15))
+                .await?;
+            return Ok(());
+        }
+        None => {
+            CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Invalid break duration")
+                .description("Use a relative duration like `5m`, `1h 30s`, or `90s`.")
+                .send_context(ctx, true, Some(15))
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let guild_id: GuildId = ctx.guild_id().ok_or(MusicBotError::NoGuildIdError)?;
+    let author_id: UserId = ctx.author().id;
+
+    let voice_channel_id: ChannelId =
+        match channel_service::get_user_voice_channel(ctx, &author_id) {
+            Some(c) => c,
+            None => {
+                BotEmbed::CurrentUserNotInVoiceChannel
+                    .to_embed()
+                    .send_context(ctx, true, Some(30))
+                    .await?;
+                return Ok(());
+            }
+        };
+
+    // Acknowledge the slash command — the timer message itself is a normal
+    // channel message so it can outlive the interaction token.
+    if let poise::Context::Application(app_ctx) = ctx {
+        let _ = app_ctx
+            .interaction
+            .create_response(
+                ctx.http(),
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content("Starting break…")
+                        .ephemeral(true),
+                ),
+            )
+            .await;
+    }
+
+    let text_channel_id: ChannelId = ctx.channel_id();
+    let started_at = Instant::now();
+    let ends_at = started_at + duration;
+
+    let mut msg: Message = text_channel_id
+        .send_message(
+            &ctx.http(),
+            CreateMessage::new()
+                .embed(build_break_embed(
+                    &ctx.author().name,
+                    duration,
+                    Instant::now(),
+                    ends_at,
+                    None,
+                ))
+                .components(break_buttons(false)),
+        )
+        .await
+        .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
+
+    let mut cancelled = false;
+    let shard = ctx.serenity_context().shard.clone();
+
+    loop {
+        let now = Instant::now();
+        if now >= ends_at {
+            break;
+        }
+
+        let remaining = ends_at.saturating_duration_since(now);
+        // Refresh roughly once per second so the countdown ticks, but no more
+        // often than that to avoid hammering the API.
+        let wait = remaining.min(Duration::from_secs(5));
+
+        let interaction = msg
+            .await_component_interaction(shard.clone())
+            .timeout(wait)
+            .await;
+
+        if let Some(ic) = interaction {
+            if ic.data.custom_id == BTN_BREAK_CANCEL {
+                if ic.user.id != author_id {
+                    ic.create_response(
+                        ctx.http(),
+                        CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content("Only the person who started the break can cancel it.")
+                                .ephemeral(true),
+                        ),
+                    )
+                    .await
+                    .ok();
+                    continue;
+                }
+                ic.create_response(ctx.http(), CreateInteractionResponse::Acknowledge)
+                    .await
+                    .ok();
+                cancelled = true;
+                break;
+            }
+        }
+
+        let _ = msg
+            .edit(
+                ctx.http(),
+                EditMessage::new()
+                    .embed(build_break_embed(
+                        &ctx.author().name,
+                        duration,
+                        Instant::now(),
+                        ends_at,
+                        None,
+                    ))
+                    .components(break_buttons(false)),
+            )
+            .await;
+    }
+
+    let footer = if cancelled {
+        "Break cancelled."
+    } else {
+        "Break is over — starting gathering."
+    };
+
+    let _ = msg
+        .edit(
+            ctx.http(),
+            EditMessage::new()
+                .embed(build_break_embed(
+                    &ctx.author().name,
+                    duration,
+                    Instant::now(),
+                    ends_at,
+                    Some(footer),
+                ))
+                .components(Vec::new()),
+        )
+        .await;
+
+    if cancelled {
+        return Ok(());
+    }
+
+    gather_service::start_gather(
+        ctx.serenity_context(),
+        guild_id,
+        text_channel_id,
+        voice_channel_id,
+        author_id,
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn parse_break_duration(text: &str) -> Option<Duration> {
+    let target = convert_time_offset_from_string(text.trim().to_string())?;
+    let now = crate::player::notifier::get_current_time();
+    let secs = (target - now).whole_seconds();
+    if secs <= 0 {
+        return None;
+    }
+    Some(Duration::from_secs(secs as u64))
+}
+
+fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {
+    vec![CreateActionRow::Buttons(vec![CreateButton::new(
+        BTN_BREAK_CANCEL,
+    )
+    .label("Cancel")
+    .style(ButtonStyle::Danger)
+    .disabled(disabled)])]
+}
+
+fn build_break_embed(
+    author_name: &str,
+    total: Duration,
+    now: Instant,
+    ends_at: Instant,
+    footer: Option<&str>,
+) -> CreateEmbed {
+    let remaining = ends_at.saturating_duration_since(now);
+    let color = if footer.is_some() {
+        Color::DARK_GREEN
+    } else {
+        Color::DARK_GOLD
+    };
+
+    let mut builder = CreateEmbed::new()
+        .color(color)
+        .title("⏸️  Break in progress")
+        .description(format!(
+            "**{}** started a break of `{}`.\n\nTime remaining: **{}**\n\n\
+             When the timer ends, everyone still in voice will be gathered \
+             automatically — late arrivals will be tracked.",
+            author_name,
+            format_hhmmss(total),
+            format_hhmmss(remaining),
+        ));
+
+    if let Some(text) = footer {
+        builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
+    }
+
+    builder
+}
+
+fn format_hhmmss(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    if h > 0 {
+        format!("{:02}:{:02}:{:02}", h, m, s)
+    } else {
+        format!("{:02}:{:02}", m, s)
+    }
+}

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -8,12 +8,13 @@ use crate::service::gather_service;
 use serenity::all::{
     ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
     CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
-    GuildId, Message, UserId,
+    GuildId, Mentionable, Message, UserId,
 };
 use std::time::{Duration, Instant};
 
 const BTN_BREAK_CANCEL: &str = "break_cancel";
 const MAX_BREAK_DURATION: Duration = Duration::from_secs(60 * 60 * 4);
+const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Take a break — when the timer runs out, everyone in voice is auto-gathered.
 #[poise::command(slash_command, prefix_command, check = "check_author_in_voice_channel")]
@@ -80,13 +81,18 @@ pub async fn r#break(
     let text_channel_id: ChannelId = ctx.channel_id();
     let started_at = Instant::now();
     let ends_at = started_at + duration;
+    let author_mention = ctx.author().mention().to_string();
 
     let mut msg: Message = text_channel_id
         .send_message(
             &ctx.http(),
             CreateMessage::new()
+                .content(format!(
+                    "@here  ⏸️  {} started a break.",
+                    author_mention
+                ))
                 .embed(build_break_embed(
-                    &ctx.author().name,
+                    &author_mention,
                     duration,
                     Instant::now(),
                     ends_at,
@@ -98,6 +104,7 @@ pub async fn r#break(
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
     let mut cancelled = false;
+    let mut last_edit = Instant::now();
     let shard = ctx.serenity_context().shard.clone();
 
     loop {
@@ -107,9 +114,7 @@ pub async fn r#break(
         }
 
         let remaining = ends_at.saturating_duration_since(now);
-        // Refresh roughly once per second so the countdown ticks, but no more
-        // often than that to avoid hammering the API.
-        let wait = remaining.min(Duration::from_secs(5));
+        let wait = remaining.min(MIN_EDIT_INTERVAL);
 
         let interaction = msg
             .await_component_interaction(shard.clone())
@@ -139,12 +144,16 @@ pub async fn r#break(
             }
         }
 
+        if Instant::now() < last_edit + MIN_EDIT_INTERVAL {
+            continue;
+        }
+        last_edit = Instant::now();
         let _ = msg
             .edit(
                 ctx.http(),
                 EditMessage::new()
                     .embed(build_break_embed(
-                        &ctx.author().name,
+                        &author_mention,
                         duration,
                         Instant::now(),
                         ends_at,
@@ -166,7 +175,7 @@ pub async fn r#break(
             ctx.http(),
             EditMessage::new()
                 .embed(build_break_embed(
-                    &ctx.author().name,
+                    &author_mention,
                     duration,
                     Instant::now(),
                     ends_at,
@@ -212,7 +221,7 @@ fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {
 }
 
 fn build_break_embed(
-    author_name: &str,
+    author_mention: &str,
     total: Duration,
     now: Instant,
     ends_at: Instant,
@@ -229,10 +238,10 @@ fn build_break_embed(
         .color(color)
         .title("⏸️  Break in progress")
         .description(format!(
-            "**{}** started a break of `{}`.\n\nTime remaining: **{}**\n\n\
+            "{} started a break of `{}`.\n\nTime remaining: **{}**\n\n\
              When the timer ends, everyone still in voice will be gathered \
              automatically — late arrivals will be tracked.",
-            author_name,
+            author_mention,
             format_hhmmss(total),
             format_hhmmss(remaining),
         ));

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -151,14 +151,32 @@ pub async fn start(
         .await
         .insert(guild_id, Arc::clone(&state));
 
+    // Ping all voice members in a separate message above the embed.
+    let bot_id = ctx.serenity_context().cache.current_user().id;
+    let voice_mentions: String = ctx
+        .serenity_context()
+        .cache
+        .guild(guild_id)
+        .as_ref()
+        .map(|g| {
+            g.voice_states
+                .values()
+                .filter(|vs| vs.channel_id == Some(voice_channel_id) && vs.user_id != bot_id)
+                .map(|vs| vs.user_id.mention().to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+    if !voice_mentions.is_empty() {
+        let _ = text_channel_id
+            .send_message(&ctx.http(), CreateMessage::new().content(voice_mentions))
+            .await;
+    }
+
     let mut msg: Message = text_channel_id
         .send_message(
             &ctx.http(),
             CreateMessage::new()
-                .content(format!(
-                    "@here  ⏸️  {} started a break.",
-                    author_mention
-                ))
                 .embed(build_break_embed(&state, None))
                 .components(break_buttons(false)),
         )

--- a/src/commands/utility/cmd_gather.rs
+++ b/src/commands/utility/cmd_gather.rs
@@ -1,0 +1,53 @@
+use crate::bot::{Context, MusicBotError};
+use crate::checks::channel_checks::check_author_in_voice_channel;
+use crate::embeds::bot_embeds::BotEmbed;
+use crate::service::channel_service;
+use crate::service::embed_service::SendEmbed;
+use crate::service::gather_service;
+use serenity::all::{
+    ChannelId, CreateInteractionResponse, CreateInteractionResponseMessage, GuildId,
+};
+
+/// Gather everyone in your voice channel — they tap "I'm here!" to check in.
+#[poise::command(slash_command, prefix_command, check = "check_author_in_voice_channel")]
+pub async fn gather(ctx: Context<'_>) -> Result<(), MusicBotError> {
+    let guild_id: GuildId = ctx.guild_id().ok_or(MusicBotError::NoGuildIdError)?;
+
+    let voice_channel_id: ChannelId = match channel_service::get_user_voice_channel(ctx, &ctx.author().id) {
+        Some(c) => c,
+        None => {
+            BotEmbed::CurrentUserNotInVoiceChannel
+                .to_embed()
+                .send_context(ctx, true, Some(30))
+                .await?;
+            return Ok(());
+        }
+    };
+
+    // Acknowledge the slash command immediately — the gathering itself runs as a
+    // regular channel message so it can outlive the interaction token.
+    if let poise::Context::Application(app_ctx) = ctx {
+        let _ = app_ctx
+            .interaction
+            .create_response(
+                ctx.http(),
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content("Starting gathering…")
+                        .ephemeral(true),
+                ),
+            )
+            .await;
+    }
+
+    gather_service::start_gather(
+        ctx.serenity_context(),
+        guild_id,
+        ctx.channel_id(),
+        voice_channel_id,
+        ctx.author().id,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/src/commands/utility/cmd_rename.rs
+++ b/src/commands/utility/cmd_rename.rs
@@ -131,12 +131,8 @@ async fn do_rename(
     CreateEmbed::new()
         .color(Color::DARK_BLUE)
         .title("✏️  Renamed")
-        .description(format!(
-            "`{}` --> `{}`\n{}",
-            previous,
-            next,
-            target.mention()
-        ))
+        .description(format!("`{}` → `{}`", previous, next))
+        .field("Target:", target.mention().to_string(), true)
         .send_context(ctx, true, None)
         .await?;
 

--- a/src/commands/utility/cmd_rename.rs
+++ b/src/commands/utility/cmd_rename.rs
@@ -131,8 +131,12 @@ async fn do_rename(
     CreateEmbed::new()
         .color(Color::DARK_BLUE)
         .title("✏️  Renamed")
-        .description(format!("{} → `{}`", target.mention(), next))
-        .field("Previous:", format!("`{previous}`"), true)
+        .description(format!(
+            "`{}` --> `{}`\n{}",
+            previous,
+            next,
+            target.mention()
+        ))
         .send_context(ctx, true, None)
         .await?;
 

--- a/src/commands/utility/mod.rs
+++ b/src/commands/utility/mod.rs
@@ -1,3 +1,5 @@
+pub mod cmd_break;
+pub mod cmd_gather;
 pub mod cmd_notify;
 pub mod cmd_rename;
 pub mod cmd_uwu;

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -13,7 +13,7 @@ const GHOST_PING_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_GATHER_DURATION: Duration = Duration::from_secs(60 * 30);
 const GHOST_PING_LIFETIME: Duration = Duration::from_millis(700);
 const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
-const MAX_NAME_LEN: usize = 16;
+const MAX_NAME_LEN: usize = 22;
 
 const BTN_HERE: &str = "gather_im_here";
 const BTN_CANCEL: &str = "gather_cancel";
@@ -192,7 +192,7 @@ pub async fn start_gather(
                         let lateness = if now <= grace_ends_at {
                             Duration::ZERO
                         } else {
-                            now - grace_ends_at
+                            now - started_at
                         };
 
                         arrivals.insert(ic.user.id, lateness);
@@ -448,12 +448,14 @@ fn build_embed(
     let elapsed = now.saturating_duration_since(started_at);
     let header = if in_grace {
         format!(
-            "Grace period: **{}** remaining (counting starts at 02:00).",
-            format_mmss(grace_remaining)
+            "Grace period: **{}** remaining (counting starts at {}).",
+            format_mmss(grace_remaining),
+            format_mmss(GRACE_PERIOD)
         )
     } else {
         format!(
-            "Counting since grace ended — elapsed since start: **{}**.",
+            "Counting since gather started — elapsed: **{}**. Late arrivals \
+             are stamped with their time-from-start.",
             format_mmss(elapsed)
         )
     };

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -1,0 +1,480 @@
+use crate::bot::MusicBotError;
+use serenity::all::{
+    ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
+    CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
+    GuildId, Mentionable, Message, UserId,
+};
+use serenity::prelude::Context as SerenityContext;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+const GRACE_PERIOD: Duration = Duration::from_secs(120);
+const GHOST_PING_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_GATHER_DURATION: Duration = Duration::from_secs(60 * 30);
+const GHOST_PING_LIFETIME: Duration = Duration::from_millis(700);
+
+const BTN_HERE: &str = "gather_im_here";
+const BTN_CANCEL: &str = "gather_cancel";
+
+pub async fn start_gather(
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    text_channel_id: ChannelId,
+    voice_channel_id: ChannelId,
+    author_id: UserId,
+) -> Result<(), MusicBotError> {
+    let bot_id = serenity_ctx.cache.current_user().id;
+
+    let expected_ids: Vec<UserId> = current_voice_members(serenity_ctx, guild_id, voice_channel_id, bot_id);
+
+    if expected_ids.is_empty() {
+        return Err(MusicBotError::InternalError(
+            "No one is in the voice channel.".to_string(),
+        ));
+    }
+
+    let started_at = Instant::now();
+    let grace_ends_at = started_at + GRACE_PERIOD;
+    let deadline = started_at + MAX_GATHER_DURATION;
+
+    let mut arrivals: HashMap<UserId, Duration> = HashMap::new();
+    // Author who initiated gather is auto-marked as present at time 0.
+    arrivals.insert(author_id, Duration::ZERO);
+
+    let mut expected: HashSet<UserId> = expected_ids.into_iter().collect();
+    expected.insert(author_id);
+
+    let mut msg: Message = text_channel_id
+        .send_message(
+            &serenity_ctx.http,
+            CreateMessage::new()
+                .content("@here  📣  Gathering in voice channel — click **I'm here!** below.")
+                .embed(build_embed(
+                    serenity_ctx,
+                    guild_id,
+                    &expected,
+                    &arrivals,
+                    started_at,
+                    grace_ends_at,
+                    None,
+                ))
+                .components(buttons(false)),
+        )
+        .await
+        .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
+
+    let mut last_ghost_ping = started_at;
+    let mut cancelled = false;
+    let shard = serenity_ctx.shard.clone();
+
+    loop {
+        let now = Instant::now();
+
+        // Stop conditions
+        if now >= deadline {
+            break;
+        }
+        if cancelled {
+            break;
+        }
+        let missing: Vec<UserId> = expected
+            .iter()
+            .filter(|id| !arrivals.contains_key(id))
+            .copied()
+            .collect();
+        if missing.is_empty() && now >= grace_ends_at {
+            // Everyone here and grace done.
+            break;
+        }
+
+        let next_ping_at = last_ghost_ping + GHOST_PING_INTERVAL;
+        let next_event = next_ping_at.min(deadline);
+        let wait = next_event.saturating_duration_since(now);
+
+        let interaction = msg
+            .await_component_interaction(shard.clone())
+            .timeout(wait)
+            .await;
+
+        match interaction {
+            Some(ic) => {
+                match ic.data.custom_id.as_str() {
+                    BTN_CANCEL => {
+                        if ic.user.id != author_id {
+                            ic.create_response(
+                                &serenity_ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content("Only the person who started the gathering can cancel it.")
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await
+                            .ok();
+                            continue;
+                        }
+                        ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
+                            .await
+                            .ok();
+                        cancelled = true;
+                    }
+                    BTN_HERE => {
+                        // Must be in the voice channel.
+                        let in_voice =
+                            user_in_voice(serenity_ctx, guild_id, voice_channel_id, ic.user.id);
+
+                        if !in_voice {
+                            ic.create_response(
+                                &serenity_ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content("You need to be in the voice channel to check in.")
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await
+                            .ok();
+                            continue;
+                        }
+
+                        if arrivals.contains_key(&ic.user.id) {
+                            ic.create_response(
+                                &serenity_ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content("You're already checked in.")
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await
+                            .ok();
+                            continue;
+                        }
+
+                        let now = Instant::now();
+                        let lateness = if now <= grace_ends_at {
+                            Duration::ZERO
+                        } else {
+                            now - grace_ends_at
+                        };
+
+                        arrivals.insert(ic.user.id, lateness);
+                        // Anyone who clicks (and is in voice) joins the expected set
+                        // even if they weren't there when the gather started.
+                        expected.insert(ic.user.id);
+
+                        ic.create_response(
+                            &serenity_ctx.http,
+                            CreateInteractionResponse::UpdateMessage(
+                                CreateInteractionResponseMessage::new()
+                                    .embed(build_embed(
+                                        serenity_ctx,
+                                        guild_id,
+                                        &expected,
+                                        &arrivals,
+                                        started_at,
+                                        grace_ends_at,
+                                        None,
+                                    ))
+                                    .components(buttons(false)),
+                            ),
+                        )
+                        .await
+                        .ok();
+                    }
+                    _ => {
+                        ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
+                            .await
+                            .ok();
+                    }
+                }
+            }
+            None => {
+                // timeout — handled below by ghost-ping check / loop conditions.
+            }
+        }
+
+        let now = Instant::now();
+
+        // Ghost-ping missing members after grace period ends.
+        if now >= grace_ends_at && now >= last_ghost_ping + GHOST_PING_INTERVAL {
+            last_ghost_ping = now;
+            let still_missing: Vec<UserId> = expected
+                .iter()
+                .filter(|id| !arrivals.contains_key(id))
+                .copied()
+                .collect();
+            if !still_missing.is_empty() {
+                ghost_ping(serenity_ctx, text_channel_id, &still_missing).await;
+            }
+        }
+
+        // Refresh embed (clock-driven changes like grace expiring should be visible).
+        let _ = msg
+            .edit(
+                &serenity_ctx.http,
+                EditMessage::new()
+                    .embed(build_embed(
+                        serenity_ctx,
+                        guild_id,
+                        &expected,
+                        &arrivals,
+                        started_at,
+                        grace_ends_at,
+                        None,
+                    ))
+                    .components(buttons(false)),
+            )
+            .await;
+    }
+
+    let footer = if cancelled {
+        Some("Cancelled by initiator.")
+    } else if Instant::now() >= deadline {
+        Some("Gathering timed out.")
+    } else {
+        Some("All checked in. Gathering complete.")
+    };
+
+    let _ = msg
+        .edit(
+            &serenity_ctx.http,
+            EditMessage::new()
+                .embed(build_embed(
+                    serenity_ctx,
+                    guild_id,
+                    &expected,
+                    &arrivals,
+                    started_at,
+                    grace_ends_at,
+                    footer,
+                ))
+                .components(Vec::new()),
+        )
+        .await;
+
+    Ok(())
+}
+
+fn current_voice_members(
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    voice_channel_id: ChannelId,
+    bot_id: UserId,
+) -> Vec<UserId> {
+    serenity_ctx
+        .cache
+        .guild(guild_id)
+        .as_ref()
+        .map(|g| {
+            g.voice_states
+                .values()
+                .filter(|vs| vs.channel_id == Some(voice_channel_id) && vs.user_id != bot_id)
+                .map(|vs| vs.user_id)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn user_in_voice(
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    voice_channel_id: ChannelId,
+    user_id: UserId,
+) -> bool {
+    serenity_ctx
+        .cache
+        .guild(guild_id)
+        .as_ref()
+        .and_then(|g| g.voice_states.get(&user_id))
+        .and_then(|vs| vs.channel_id)
+        == Some(voice_channel_id)
+}
+
+fn buttons(disabled: bool) -> Vec<CreateActionRow> {
+    vec![CreateActionRow::Buttons(vec![
+        CreateButton::new(BTN_HERE)
+            .label("I'm here!")
+            .style(ButtonStyle::Success)
+            .disabled(disabled),
+        CreateButton::new(BTN_CANCEL)
+            .label("Cancel")
+            .style(ButtonStyle::Danger)
+            .disabled(disabled),
+    ])]
+}
+
+fn build_embed(
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    expected: &HashSet<UserId>,
+    arrivals: &HashMap<UserId, Duration>,
+    started_at: Instant,
+    grace_ends_at: Instant,
+    footer: Option<&str>,
+) -> CreateEmbed {
+    let now = Instant::now();
+    let in_grace = now < grace_ends_at;
+    let grace_remaining = grace_ends_at.saturating_duration_since(now);
+
+    // Resolve names once with a single cache borrow.
+    let names: HashMap<UserId, String> = {
+        let guild = serenity_ctx.cache.guild(guild_id);
+        expected
+            .iter()
+            .map(|id| {
+                let name = guild
+                    .as_ref()
+                    .and_then(|g| g.members.get(id))
+                    .map(|m| m.display_name().to_string())
+                    .unwrap_or_else(|| format!("User {}", id.get()));
+                (*id, name)
+            })
+            .collect()
+    };
+
+    let mut rows: Vec<(String, String)> = expected
+        .iter()
+        .map(|id| {
+            let name = names.get(id).cloned().unwrap_or_default();
+            let status = match arrivals.get(id) {
+                Some(d) if d.is_zero() => "ON TIME".to_string(),
+                Some(d) => format!("+{}", format_mmss(*d)),
+                None => "--:--".to_string(),
+            };
+            (name, status)
+        })
+        .collect();
+
+    // Sort: present first (by arrival time), then missing.
+    rows.sort_by(|a, b| {
+        let aa = arrivals_order(arrivals, a, &names);
+        let bb = arrivals_order(arrivals, b, &names);
+        aa.cmp(&bb)
+    });
+
+    let name_width = rows
+        .iter()
+        .map(|(n, _)| n.chars().count())
+        .max()
+        .unwrap_or(4)
+        .clamp(4, 24);
+    let status_width = rows
+        .iter()
+        .map(|(_, s)| s.chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+
+    let mut table = String::new();
+    let sep = format!(
+        "+{}+{}+\n",
+        "-".repeat(name_width + 2),
+        "-".repeat(status_width + 2)
+    );
+    table.push_str(&sep);
+    table.push_str(&format!(
+        "| {:<nw$} | {:<sw$} |\n",
+        "User",
+        "Arrived",
+        nw = name_width,
+        sw = status_width
+    ));
+    table.push_str(&sep);
+    for (name, status) in &rows {
+        let trimmed: String = name.chars().take(name_width).collect();
+        table.push_str(&format!(
+            "| {:<nw$} | {:<sw$} |\n",
+            trimmed,
+            status,
+            nw = name_width,
+            sw = status_width
+        ));
+    }
+    table.push_str(&sep);
+
+    let elapsed = now.saturating_duration_since(started_at);
+    let header = if in_grace {
+        format!(
+            "Grace period: **{}** remaining (counting starts at 02:00).",
+            format_mmss(grace_remaining)
+        )
+    } else {
+        format!(
+            "Counting since grace ended — elapsed since start: **{}**.",
+            format_mmss(elapsed)
+        )
+    };
+
+    let present = arrivals.len();
+    let total = expected.len();
+
+    let color = if footer.is_some() {
+        Color::DARK_GREEN
+    } else if in_grace {
+        Color::DARK_BLUE
+    } else {
+        Color::ORANGE
+    };
+
+    let mut builder = CreateEmbed::new()
+        .color(color)
+        .title("📣  Voice Channel Gathering")
+        .description(format!(
+            "{}\n\nAttendance: **{}/{}**\n```\n{}```",
+            header, present, total, table
+        ));
+
+    if let Some(text) = footer {
+        builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
+    }
+
+    builder
+}
+
+fn arrivals_order(
+    arrivals: &HashMap<UserId, Duration>,
+    row: &(String, String),
+    names: &HashMap<UserId, String>,
+) -> (u8, u128, String) {
+    let id_for_name = names
+        .iter()
+        .find_map(|(id, n)| if n == &row.0 { Some(*id) } else { None });
+    match id_for_name.and_then(|id| arrivals.get(&id)) {
+        Some(d) => (0, d.as_millis(), row.0.clone()),
+        None => (1, 0, row.0.clone()),
+    }
+}
+
+fn format_mmss(d: Duration) -> String {
+    let total = d.as_secs();
+    let m = total / 60;
+    let s = total % 60;
+    format!("{:02}:{:02}", m, s)
+}
+
+async fn ghost_ping(
+    serenity_ctx: &SerenityContext,
+    text_channel_id: ChannelId,
+    users: &[UserId],
+) {
+    let content = users
+        .iter()
+        .map(|u| u.mention().to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let sent = text_channel_id
+        .send_message(&serenity_ctx.http, CreateMessage::new().content(content))
+        .await;
+
+    if let Ok(m) = sent {
+        let http = serenity_ctx.http.clone();
+        let ch = text_channel_id;
+        let mid = m.id;
+        tokio::spawn(async move {
+            tokio::time::sleep(GHOST_PING_LIFETIME).await;
+            let _ = http.delete_message(ch, mid, Some("gather ghost ping")).await;
+        });
+    }
+}

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -13,6 +13,7 @@ const GHOST_PING_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_GATHER_DURATION: Duration = Duration::from_secs(60 * 30);
 const GHOST_PING_LIFETIME: Duration = Duration::from_millis(700);
 const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
+const MAX_NAME_LEN: usize = 16;
 
 const BTN_HERE: &str = "gather_im_here";
 const BTN_CANCEL: &str = "gather_cancel";
@@ -374,12 +375,12 @@ fn build_embed(
         expected
             .iter()
             .map(|id| {
-                let name = guild
+                let raw = guild
                     .as_ref()
                     .and_then(|g| g.members.get(id))
                     .map(|m| m.display_name().to_string())
                     .unwrap_or_else(|| format!("User {}", id.get()));
-                (*id, name)
+                (*id, sanitize_name(&raw))
             })
             .collect()
     };
@@ -409,7 +410,7 @@ fn build_embed(
         .map(|(n, _)| n.chars().count())
         .max()
         .unwrap_or(4)
-        .clamp(4, 24);
+        .clamp(4, MAX_NAME_LEN);
     let status_width = rows
         .iter()
         .map(|(_, s)| s.chars().count())
@@ -495,6 +496,27 @@ fn arrivals_order(
         Some(d) => (0, d.as_millis(), row.0.clone()),
         None => (1, 0, row.0.clone()),
     }
+}
+
+/// Replace emoji grapheme clusters with their `:shortcode:` (or `:name:`),
+/// then truncate to `MAX_NAME_LEN` chars so the table stays aligned in
+/// Discord's monospace code block font.
+fn sanitize_name(name: &str) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
+
+    let mut out = String::new();
+    for g in name.graphemes(true) {
+        if let Some(emoji) = emojis::get(g) {
+            let label = emoji.shortcode().unwrap_or(emoji.name());
+            out.push(':');
+            out.push_str(label.trim_matches(':'));
+            out.push(':');
+        } else {
+            out.push_str(g);
+        }
+    }
+
+    out.chars().take(MAX_NAME_LEN).collect()
 }
 
 fn format_mmss(d: Duration) -> String {

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -8,13 +8,15 @@ use serenity::prelude::Context as SerenityContext;
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
-const GRACE_PERIOD: Duration = Duration::from_secs(120);
+const GRACE_PERIOD: Duration = Duration::from_secs(60);
 const GHOST_PING_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_GATHER_DURATION: Duration = Duration::from_secs(60 * 30);
 const GHOST_PING_LIFETIME: Duration = Duration::from_millis(700);
+const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
 
 const BTN_HERE: &str = "gather_im_here";
 const BTN_CANCEL: &str = "gather_cancel";
+const BTN_FORCE_START: &str = "gather_force_start";
 
 pub async fn start_gather(
     serenity_ctx: &SerenityContext,
@@ -34,7 +36,7 @@ pub async fn start_gather(
     }
 
     let started_at = Instant::now();
-    let grace_ends_at = started_at + GRACE_PERIOD;
+    let mut grace_ends_at = started_at + GRACE_PERIOD;
     let deadline = started_at + MAX_GATHER_DURATION;
 
     let mut arrivals: HashMap<UserId, Duration> = HashMap::new();
@@ -62,6 +64,7 @@ pub async fn start_gather(
         .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
 
     let mut last_ghost_ping = started_at;
+    let mut last_edit = Instant::now();
     let mut cancelled = false;
     let shard = serenity_ctx.shard.clone();
 
@@ -115,6 +118,41 @@ pub async fn start_gather(
                             .await
                             .ok();
                         cancelled = true;
+                    }
+                    BTN_FORCE_START => {
+                        if ic.user.id != author_id {
+                            ic.create_response(
+                                &serenity_ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content("Only the person who started the gathering can force-start it.")
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await
+                            .ok();
+                            continue;
+                        }
+                        grace_ends_at = Instant::now();
+                        ic.create_response(
+                            &serenity_ctx.http,
+                            CreateInteractionResponse::UpdateMessage(
+                                CreateInteractionResponseMessage::new()
+                                    .embed(build_embed(
+                                        serenity_ctx,
+                                        guild_id,
+                                        &expected,
+                                        &arrivals,
+                                        started_at,
+                                        grace_ends_at,
+                                        None,
+                                    ))
+                                    .components(buttons(false)),
+                            ),
+                        )
+                        .await
+                        .ok();
+                        last_edit = Instant::now();
                     }
                     BTN_HERE => {
                         // Must be in the voice channel.
@@ -179,6 +217,7 @@ pub async fn start_gather(
                         )
                         .await
                         .ok();
+                        last_edit = Instant::now();
                     }
                     _ => {
                         ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
@@ -213,6 +252,11 @@ pub async fn start_gather(
         }
 
         // Refresh embed (clock-driven changes like grace expiring should be visible).
+        // Throttled to avoid hitting Discord's per-message edit rate limit.
+        if Instant::now() < last_edit + MIN_EDIT_INTERVAL {
+            continue;
+        }
+        last_edit = Instant::now();
         let _ = msg
             .edit(
                 &serenity_ctx.http,
@@ -299,6 +343,10 @@ fn buttons(disabled: bool) -> Vec<CreateActionRow> {
         CreateButton::new(BTN_HERE)
             .label("I'm here!")
             .style(ButtonStyle::Success)
+            .disabled(disabled),
+        CreateButton::new(BTN_FORCE_START)
+            .label("Force start")
+            .style(ButtonStyle::Primary)
             .disabled(disabled),
         CreateButton::new(BTN_CANCEL)
             .label("Cancel")

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -50,20 +50,24 @@ pub async fn start_gather(
     let mut expected: HashSet<UserId> = expected_ids.iter().copied().collect();
     expected.insert(author_id);
 
-    // Ping only the users currently in voice instead of @here.
+    // Ping all voice members in a standalone message so the mention appears
+    // above the embed and is not baked into the embed message itself.
     let voice_mentions: String = expected_ids
         .iter()
         .map(|id| id.mention().to_string())
         .collect::<Vec<_>>()
         .join(" ");
+    let _ = text_channel_id
+        .send_message(
+            &serenity_ctx.http,
+            CreateMessage::new().content(voice_mentions),
+        )
+        .await;
 
     let mut msg: Message = text_channel_id
         .send_message(
             &serenity_ctx.http,
             CreateMessage::new()
-                .content(format!(
-                    "{voice_mentions}  📣  Gathering in voice channel — click **I'm here!** below."
-                ))
                 .embed(build_embed(
                     serenity_ctx,
                     guild_id,

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -38,8 +38,6 @@ pub async fn start_gather(
     let deadline = started_at + MAX_GATHER_DURATION;
 
     let mut arrivals: HashMap<UserId, Duration> = HashMap::new();
-    // Author who initiated gather is auto-marked as present at time 0.
-    arrivals.insert(author_id, Duration::ZERO);
 
     let mut expected: HashSet<UserId> = expected_ids.into_iter().collect();
     expected.insert(author_id);
@@ -195,6 +193,11 @@ pub async fn start_gather(
         }
 
         let now = Instant::now();
+
+        // Track anyone who has joined the voice channel since gather started.
+        for id in current_voice_members(serenity_ctx, guild_id, voice_channel_id, bot_id) {
+            expected.insert(id);
+        }
 
         // Ghost-ping missing members after grace period ends.
         if now >= grace_ends_at && now >= last_ghost_ping + GHOST_PING_INTERVAL {

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -1,11 +1,14 @@
 use crate::bot::MusicBotError;
 use serenity::all::{
-    ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
-    CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
-    GuildId, Mentionable, Message, UserId,
+    ButtonStyle, ChannelId, Color, ComponentInteractionCollector, CreateActionRow, CreateButton,
+    CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage,
+    EditMessage, GuildId, Mentionable, Message, UserId,
 };
+use serenity::futures::StreamExt;
+use serenity::http::Http;
 use serenity::prelude::Context as SerenityContext;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 const GRACE_PERIOD: Duration = Duration::from_secs(60);
@@ -14,6 +17,8 @@ const MAX_GATHER_DURATION: Duration = Duration::from_secs(60 * 30);
 const GHOST_PING_LIFETIME: Duration = Duration::from_millis(700);
 const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
 const MAX_NAME_LEN: usize = 22;
+// Max wait in the select loop — keeps button response latency well within 3 s.
+const LOOP_POLL: Duration = Duration::from_millis(800);
 
 const BTN_HERE: &str = "gather_im_here";
 const BTN_CANCEL: &str = "gather_cancel";
@@ -28,7 +33,8 @@ pub async fn start_gather(
 ) -> Result<(), MusicBotError> {
     let bot_id = serenity_ctx.cache.current_user().id;
 
-    let expected_ids: Vec<UserId> = current_voice_members(serenity_ctx, guild_id, voice_channel_id, bot_id);
+    let expected_ids: Vec<UserId> =
+        current_voice_members(serenity_ctx, guild_id, voice_channel_id, bot_id);
 
     if expected_ids.is_empty() {
         return Err(MusicBotError::InternalError(
@@ -41,15 +47,23 @@ pub async fn start_gather(
     let deadline = started_at + MAX_GATHER_DURATION;
 
     let mut arrivals: HashMap<UserId, Duration> = HashMap::new();
-
-    let mut expected: HashSet<UserId> = expected_ids.into_iter().collect();
+    let mut expected: HashSet<UserId> = expected_ids.iter().copied().collect();
     expected.insert(author_id);
+
+    // Ping only the users currently in voice instead of @here.
+    let voice_mentions: String = expected_ids
+        .iter()
+        .map(|id| id.mention().to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
 
     let mut msg: Message = text_channel_id
         .send_message(
             &serenity_ctx.http,
             CreateMessage::new()
-                .content("@here  📣  Gathering in voice channel — click **I'm here!** below.")
+                .content(format!(
+                    "{voice_mentions}  📣  Gathering in voice channel — click **I'm here!** below."
+                ))
                 .embed(build_embed(
                     serenity_ctx,
                     guild_id,
@@ -67,213 +81,102 @@ pub async fn start_gather(
     let mut last_ghost_ping = started_at;
     let mut last_edit = Instant::now();
     let mut cancelled = false;
-    let shard = serenity_ctx.shard.clone();
+
+    // A persistent stream buffers every interaction on this message so no
+    // button click is ever dropped between loop iterations.
+    let interaction_stream = ComponentInteractionCollector::new(serenity_ctx)
+        .message_id(msg.id)
+        .stream();
+    tokio::pin!(interaction_stream);
 
     loop {
         let now = Instant::now();
-
-        // Stop conditions
-        if now >= deadline {
-            break;
-        }
-        if cancelled {
-            break;
-        }
-        let missing: Vec<UserId> = expected
-            .iter()
-            .filter(|id| !arrivals.contains_key(id))
-            .copied()
-            .collect();
-        if missing.is_empty() && now >= grace_ends_at {
-            // Everyone here and grace done.
+        if now >= deadline || cancelled {
             break;
         }
 
-        let next_ping_at = last_ghost_ping + GHOST_PING_INTERVAL;
-        let next_event = next_ping_at.min(deadline);
-        let wait = next_event.saturating_duration_since(now);
+        // If everyone has arrived, end the grace period right now and exit.
+        if expected.iter().all(|id| arrivals.contains_key(id)) {
+            grace_ends_at = grace_ends_at.min(now);
+            break;
+        }
 
-        let interaction = msg
-            .await_component_interaction(shard.clone())
-            .timeout(wait)
-            .await;
+        let next_periodic = if now < grace_ends_at {
+            grace_ends_at
+        } else {
+            (last_ghost_ping + GHOST_PING_INTERVAL).min(deadline)
+        };
+        let wait = next_periodic
+            .saturating_duration_since(now)
+            .min(LOOP_POLL);
 
-        match interaction {
-            Some(ic) => {
-                match ic.data.custom_id.as_str() {
-                    BTN_CANCEL => {
-                        if ic.user.id != author_id {
-                            ic.create_response(
-                                &serenity_ctx.http,
-                                CreateInteractionResponse::Message(
-                                    CreateInteractionResponseMessage::new()
-                                        .content("Only the person who started the gathering can cancel it.")
-                                        .ephemeral(true),
-                                ),
-                            )
-                            .await
-                            .ok();
-                            continue;
-                        }
-                        ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
-                            .await
-                            .ok();
-                        cancelled = true;
-                    }
-                    BTN_FORCE_START => {
-                        if ic.user.id != author_id {
-                            ic.create_response(
-                                &serenity_ctx.http,
-                                CreateInteractionResponse::Message(
-                                    CreateInteractionResponseMessage::new()
-                                        .content("Only the person who started the gathering can force-start it.")
-                                        .ephemeral(true),
-                                ),
-                            )
-                            .await
-                            .ok();
-                            continue;
-                        }
-                        grace_ends_at = Instant::now();
-                        ic.create_response(
-                            &serenity_ctx.http,
-                            CreateInteractionResponse::UpdateMessage(
-                                CreateInteractionResponseMessage::new()
-                                    .embed(build_embed(
-                                        serenity_ctx,
-                                        guild_id,
-                                        &expected,
-                                        &arrivals,
-                                        started_at,
-                                        grace_ends_at,
-                                        None,
-                                    ))
-                                    .components(buttons(false)),
-                            ),
-                        )
-                        .await
-                        .ok();
-                        last_edit = Instant::now();
-                    }
-                    BTN_HERE => {
-                        // Must be in the voice channel.
-                        let in_voice =
-                            user_in_voice(serenity_ctx, guild_id, voice_channel_id, ic.user.id);
-
-                        if !in_voice {
-                            ic.create_response(
-                                &serenity_ctx.http,
-                                CreateInteractionResponse::Message(
-                                    CreateInteractionResponseMessage::new()
-                                        .content("You need to be in the voice channel to check in.")
-                                        .ephemeral(true),
-                                ),
-                            )
-                            .await
-                            .ok();
-                            continue;
-                        }
-
-                        if arrivals.contains_key(&ic.user.id) {
-                            ic.create_response(
-                                &serenity_ctx.http,
-                                CreateInteractionResponse::Message(
-                                    CreateInteractionResponseMessage::new()
-                                        .content("You're already checked in.")
-                                        .ephemeral(true),
-                                ),
-                            )
-                            .await
-                            .ok();
-                            continue;
-                        }
-
-                        let now = Instant::now();
-                        let lateness = if now <= grace_ends_at {
-                            Duration::ZERO
-                        } else {
-                            now - started_at
-                        };
-
-                        arrivals.insert(ic.user.id, lateness);
-                        // Anyone who clicks (and is in voice) joins the expected set
-                        // even if they weren't there when the gather started.
-                        expected.insert(ic.user.id);
-
-                        ic.create_response(
-                            &serenity_ctx.http,
-                            CreateInteractionResponse::UpdateMessage(
-                                CreateInteractionResponseMessage::new()
-                                    .embed(build_embed(
-                                        serenity_ctx,
-                                        guild_id,
-                                        &expected,
-                                        &arrivals,
-                                        started_at,
-                                        grace_ends_at,
-                                        None,
-                                    ))
-                                    .components(buttons(false)),
-                            ),
-                        )
-                        .await
-                        .ok();
-                        last_edit = Instant::now();
-                    }
-                    _ => {
-                        ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
-                            .await
-                            .ok();
-                    }
+        tokio::select! {
+            ic = interaction_stream.next() => {
+                match ic {
+                    Some(ic) => handle_interaction(
+                        &ic,
+                        serenity_ctx,
+                        guild_id,
+                        voice_channel_id,
+                        author_id,
+                        started_at,
+                        &mut grace_ends_at,
+                        &mut expected,
+                        &mut arrivals,
+                        &mut cancelled,
+                        &mut last_edit,
+                    )
+                    .await,
+                    None => break,
                 }
             }
-            None => {
-                // timeout — handled below by ghost-ping check / loop conditions.
-            }
+            _ = tokio::time::sleep(wait) => {}
         }
 
         let now = Instant::now();
 
-        // Track anyone who has joined the voice channel since gather started.
+        // Track late joiners from voice channel.
         for id in current_voice_members(serenity_ctx, guild_id, voice_channel_id, bot_id) {
             expected.insert(id);
         }
 
-        // Ghost-ping missing members after grace period ends.
+        // Ghost-ping missing members after grace expires.
         if now >= grace_ends_at && now >= last_ghost_ping + GHOST_PING_INTERVAL {
             last_ghost_ping = now;
-            let still_missing: Vec<UserId> = expected
+            let missing: Vec<UserId> = expected
                 .iter()
                 .filter(|id| !arrivals.contains_key(id))
                 .copied()
                 .collect();
-            if !still_missing.is_empty() {
-                ghost_ping(serenity_ctx, text_channel_id, &still_missing).await;
+            if !missing.is_empty() {
+                tokio::spawn(ghost_ping(
+                    serenity_ctx.http.clone(),
+                    text_channel_id,
+                    missing,
+                ));
             }
         }
 
-        // Refresh embed (clock-driven changes like grace expiring should be visible).
-        // Throttled to avoid hitting Discord's per-message edit rate limit.
-        if Instant::now() < last_edit + MIN_EDIT_INTERVAL {
-            continue;
+        // Throttled periodic embed refresh.
+        if Instant::now() >= last_edit + MIN_EDIT_INTERVAL {
+            last_edit = Instant::now();
+            let _ = msg
+                .edit(
+                    &serenity_ctx.http,
+                    EditMessage::new()
+                        .embed(build_embed(
+                            serenity_ctx,
+                            guild_id,
+                            &expected,
+                            &arrivals,
+                            started_at,
+                            grace_ends_at,
+                            None,
+                        ))
+                        .components(buttons(false)),
+                )
+                .await;
         }
-        last_edit = Instant::now();
-        let _ = msg
-            .edit(
-                &serenity_ctx.http,
-                EditMessage::new()
-                    .embed(build_embed(
-                        serenity_ctx,
-                        guild_id,
-                        &expected,
-                        &arrivals,
-                        started_at,
-                        grace_ends_at,
-                        None,
-                    ))
-                    .components(buttons(false)),
-            )
-            .await;
     }
 
     let footer = if cancelled {
@@ -302,6 +205,149 @@ pub async fn start_gather(
         .await;
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_interaction(
+    ic: &serenity::all::ComponentInteraction,
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    voice_channel_id: ChannelId,
+    author_id: UserId,
+    started_at: Instant,
+    grace_ends_at: &mut Instant,
+    expected: &mut HashSet<UserId>,
+    arrivals: &mut HashMap<UserId, Duration>,
+    cancelled: &mut bool,
+    last_edit: &mut Instant,
+) {
+    match ic.data.custom_id.as_str() {
+        BTN_CANCEL => {
+            if ic.user.id != author_id {
+                ic.create_response(
+                    &serenity_ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("Only the person who started the gathering can cancel it.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await
+                .ok();
+                return;
+            }
+            ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
+                .await
+                .ok();
+            *cancelled = true;
+        }
+        BTN_FORCE_START => {
+            if ic.user.id != author_id {
+                ic.create_response(
+                    &serenity_ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content(
+                                "Only the person who started the gathering can force-start it.",
+                            )
+                            .ephemeral(true),
+                    ),
+                )
+                .await
+                .ok();
+                return;
+            }
+            *grace_ends_at = Instant::now();
+            ic.create_response(
+                &serenity_ctx.http,
+                CreateInteractionResponse::UpdateMessage(
+                    CreateInteractionResponseMessage::new()
+                        .embed(build_embed(
+                            serenity_ctx,
+                            guild_id,
+                            expected,
+                            arrivals,
+                            started_at,
+                            *grace_ends_at,
+                            None,
+                        ))
+                        .components(buttons(false)),
+                ),
+            )
+            .await
+            .ok();
+            *last_edit = Instant::now();
+        }
+        BTN_HERE => {
+            if !user_in_voice(serenity_ctx, guild_id, voice_channel_id, ic.user.id) {
+                ic.create_response(
+                    &serenity_ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("You need to be in the voice channel to check in.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await
+                .ok();
+                return;
+            }
+
+            if arrivals.contains_key(&ic.user.id) {
+                ic.create_response(
+                    &serenity_ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("You're already checked in.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await
+                .ok();
+                return;
+            }
+
+            let now = Instant::now();
+            let lateness = if now <= *grace_ends_at {
+                Duration::ZERO
+            } else {
+                now - started_at
+            };
+
+            arrivals.insert(ic.user.id, lateness);
+            expected.insert(ic.user.id);
+
+            // If everyone has now arrived during grace, end grace immediately.
+            if expected.iter().all(|id| arrivals.contains_key(id)) {
+                *grace_ends_at = now;
+            }
+
+            ic.create_response(
+                &serenity_ctx.http,
+                CreateInteractionResponse::UpdateMessage(
+                    CreateInteractionResponseMessage::new()
+                        .embed(build_embed(
+                            serenity_ctx,
+                            guild_id,
+                            expected,
+                            arrivals,
+                            started_at,
+                            *grace_ends_at,
+                            None,
+                        ))
+                        .components(buttons(false)),
+                ),
+            )
+            .await
+            .ok();
+            *last_edit = Instant::now();
+        }
+        _ => {
+            ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
+                .await
+                .ok();
+        }
+    }
 }
 
 fn current_voice_members(
@@ -369,7 +415,6 @@ fn build_embed(
     let in_grace = now < grace_ends_at;
     let grace_remaining = grace_ends_at.saturating_duration_since(now);
 
-    // Resolve names once with a single cache borrow.
     let names: HashMap<UserId, String> = {
         let guild = serenity_ctx.cache.guild(guild_id);
         expected
@@ -398,7 +443,6 @@ fn build_embed(
         })
         .collect();
 
-    // Sort: present first (by arrival time), then missing.
     rows.sort_by(|a, b| {
         let aa = arrivals_order(arrivals, a, &names);
         let bb = arrivals_order(arrivals, b, &names);
@@ -454,8 +498,7 @@ fn build_embed(
         )
     } else {
         format!(
-            "Counting since gather started — elapsed: **{}**. Late arrivals \
-             are stamped with their time-from-start.",
+            "Counting since gather started — elapsed: **{}**.\nLate arrivals are stamped with their time-from-start.",
             format_mmss(elapsed)
         )
     };
@@ -500,9 +543,15 @@ fn arrivals_order(
     }
 }
 
-/// Replace emoji grapheme clusters with their `:shortcode:` (or `:name:`),
-/// then truncate to `MAX_NAME_LEN` chars so the table stays aligned in
-/// Discord's monospace code block font.
+fn format_mmss(d: Duration) -> String {
+    let total = d.as_secs();
+    let m = total / 60;
+    let s = total % 60;
+    format!("{:02}:{:02}", m, s)
+}
+
+/// Replace emoji grapheme clusters with their `:shortcode:` then truncate
+/// to MAX_NAME_LEN so the table stays aligned in Discord's monospace font.
 fn sanitize_name(name: &str) -> String {
     use unicode_segmentation::UnicodeSegmentation;
 
@@ -521,18 +570,7 @@ fn sanitize_name(name: &str) -> String {
     out.chars().take(MAX_NAME_LEN).collect()
 }
 
-fn format_mmss(d: Duration) -> String {
-    let total = d.as_secs();
-    let m = total / 60;
-    let s = total % 60;
-    format!("{:02}:{:02}", m, s)
-}
-
-async fn ghost_ping(
-    serenity_ctx: &SerenityContext,
-    text_channel_id: ChannelId,
-    users: &[UserId],
-) {
+async fn ghost_ping(http: Arc<Http>, text_channel_id: ChannelId, users: Vec<UserId>) {
     let content = users
         .iter()
         .map(|u| u.mention().to_string())
@@ -540,16 +578,18 @@ async fn ghost_ping(
         .join(" ");
 
     let sent = text_channel_id
-        .send_message(&serenity_ctx.http, CreateMessage::new().content(content))
+        .send_message(&http, CreateMessage::new().content(content))
         .await;
 
     if let Ok(m) = sent {
-        let http = serenity_ctx.http.clone();
+        let http_clone = http.clone();
         let ch = text_channel_id;
         let mid = m.id;
         tokio::spawn(async move {
             tokio::time::sleep(GHOST_PING_LIFETIME).await;
-            let _ = http.delete_message(ch, mid, Some("gather ghost ping")).await;
+            let _ = http_clone
+                .delete_message(ch, mid, Some("gather ghost ping"))
+                .await;
         });
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,6 +1,7 @@
 pub mod cache_service;
 pub mod channel_service;
 pub mod embed_service;
+pub mod gather_service;
 pub mod local_service;
 pub mod normalize_service;
 pub mod utils_service;


### PR DESCRIPTION
## Summary
This PR introduces two new Discord bot commands for coordinating voice channel activities: `/gather` for checking in voice channel members and `/break` for scheduling timed breaks with automatic gathering at the end.

## Key Changes

### New Features
- **Voice Channel Gathering** (`/gather` command)
  - Initiates a gathering where voice channel members can check in via an "I'm here!" button
  - Implements a grace period (60 seconds) during which members can arrive without being marked late
  - Tracks arrival times and displays a formatted table of attendance
  - Supports force-start and cancellation by the initiator
  - Implements ghost-pinging (temporary mentions that auto-delete) for missing members after grace period expires
  - Maximum gathering duration of 30 minutes with automatic timeout

- **Break Timer** (`/break start` and `/break extend` subcommands)
  - Allows initiating a timed break with customizable duration (up to 4 hours)
  - Supports extending active breaks via `/break extend`
  - Automatically triggers a gathering when the break timer expires
  - Displays countdown with wall-clock end time
  - Only the break initiator can cancel or extend

### Implementation Details
- **Gather Service** (`src/service/gather_service.rs`)
  - Uses `tokio::select!` for efficient async event handling with button interactions and periodic updates
  - Throttled embed updates (minimum 5-second intervals) to avoid API rate limiting
  - Tracks late arrivals with precise timing relative to grace period expiration
  - Sanitizes Discord usernames by converting emoji to shortcodes and truncating for monospace table alignment
  - Implements ghost-pinging with automatic message deletion after 700ms

- **Break Command** (`src/commands/utility/cmd_break.rs`)
  - Shared mutable `BreakState` struct allows `/break extend` to modify an active break's duration
  - Parses human-readable duration strings (e.g., "5m", "1h 30s")
  - Prevents multiple concurrent breaks per guild
  - Integrates seamlessly with the gather service for post-break automatic gathering

- **Gather Command** (`src/commands/utility/cmd_gather.rs`)
  - Simple wrapper that validates user is in voice channel and delegates to gather service

### Dependencies Added
- `emojis = "0.6"` - For emoji detection and shortcode conversion
- `unicode-segmentation = "1.11"` - For proper grapheme cluster handling in name sanitization

### Data Structure Changes
- Added `BreakState` to bot data for tracking active breaks per guild
- Integrated break state management into the main bot context

https://claude.ai/code/session_01JKuEAGY4GtSZK4yX6hXopG