### PR TITLE
Refactor time parsing to separate offset and duration logic

### DIFF
--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -1,7 +1,7 @@
 use crate::bot::{Context, MusicBotError};
 use crate::checks::channel_checks::check_author_in_voice_channel;
 use crate::embeds::bot_embeds::BotEmbed;
-use crate::player::notifier::{convert_time_offset_from_string, get_current_time};
+use crate::player::notifier::{get_current_time, parse_duration_from_string};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use crate::service::gather_service;
@@ -352,13 +352,11 @@ pub async fn extend(
 }
 
 fn parse_break_duration(text: &str) -> Option<Duration> {
-    let target = convert_time_offset_from_string(text.trim().to_string())?;
-    let now = get_current_time();
-    let secs = (target - now).whole_seconds();
-    if secs <= 0 {
+    let d = parse_duration_from_string(text.trim())?;
+    if d == Duration::ZERO {
         return None;
     }
-    Some(Duration::from_secs(secs as u64))
+    Some(d)
 }
 
 fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {

--- a/src/player/notifier.rs
+++ b/src/player/notifier.rs
@@ -377,12 +377,12 @@ pub fn convert_time_date_from_string(text: String) -> Option<OffsetDateTime> {
     None
 }
 
-pub fn convert_time_offset_from_string(text: String) -> Option<OffsetDateTime> {
+fn parse_offset_secs(text: &str) -> Option<u64> {
     let re: Regex = Regex::new(
         r"^(?:(\d+)mo(?:nths?)?)?\s*(?:(\d+)\s*d(?:ays?)?)?\s*(?:(\d+)\s*h(?:ours?)?)?\s*(?:(\d+)\s*m(?:inutes?)?)?\s*(?:(\d+)\s*s(?:econds?)?)?$"
     ).unwrap();
 
-    let captures = re.captures(text.as_str())?;
+    let captures = re.captures(text)?;
 
     let mut total_secs: u64 = 0;
     let mut matched_any = false;
@@ -407,7 +407,20 @@ pub fn convert_time_offset_from_string(text: String) -> Option<OffsetDateTime> {
         return None;
     }
 
-    Some(get_current_time().add(Duration::from_secs(total_secs)))
+    Some(total_secs)
+}
+
+pub fn convert_time_offset_from_string(text: String) -> Option<OffsetDateTime> {
+    let secs = parse_offset_secs(text.as_str())?;
+    Some(get_current_time().add(Duration::from_secs(secs)))
+}
+
+/// Parse a relative duration string (e.g. `"5m"`, `"1h 30s"`) into a `Duration`.
+/// Unlike [`convert_time_offset_from_string`], this never touches the wall clock,
+/// so the returned value is always exact.
+pub fn parse_duration_from_string(text: &str) -> Option<Duration> {
+    let secs = parse_offset_secs(text)?;
+    Some(Duration::from_secs(secs))
 }
 
 pub fn format_time(offset_date_time: OffsetDateTime) -> String {


### PR DESCRIPTION
## Summary
This PR refactors the time parsing logic in the notifier module to separate concerns between parsing relative durations and parsing time offsets from the current time. A new `parse_duration_from_string` function is introduced that parses relative duration strings without touching the wall clock, making it more suitable for use cases where an exact duration is needed rather than a future timestamp.

## Key Changes
- **Extract `parse_offset_secs` helper function**: Created a private function that handles the core regex parsing and seconds calculation logic, eliminating duplication
- **Introduce `parse_duration_from_string` function**: New public function that parses relative duration strings (e.g., `"5m"`, `"1h 30s"`) into a `Duration` without referencing the current time
- **Simplify `convert_time_offset_from_string`**: Now delegates to `parse_offset_secs` and only handles the time offset calculation
- **Update `cmd_break.rs`**: Refactored `parse_break_duration` to use the new `parse_duration_from_string` function, eliminating unnecessary wall clock queries and simplifying the logic
- **Minor improvements**: Changed `text.as_str()` to `text` in regex capture call for cleaner code

## Implementation Details
The refactoring maintains backward compatibility while improving code clarity. The new `parse_duration_from_string` function is more efficient for break duration parsing since it doesn't need to calculate the difference between a future timestamp and the current time—it directly returns the duration value.

https://claude.ai/code/session_0189Q4SF1d677JBdnyjeCUcp