### PR TITLE
Improve gather flow and add clock time support for breaks

### DIFF
--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -27,6 +27,9 @@ pub struct BreakState {
     pub original_duration: Duration,
     pub extension: Mutex<Duration>,
     pub author_mention: String,
+    /// Set when the break was started with a clock time (e.g. "17:10") rather
+    /// than a relative duration. Controls the embed wording.
+    pub clock_time_label: Option<String>,
 }
 
 impl BreakState {
@@ -65,8 +68,8 @@ pub async fn start(
     ctx: Context<'_>,
     #[description = "Break end time or duration, e.g. `5m`, `1h 30s`, `14:00`."] time: String,
 ) -> Result<(), MusicBotError> {
-    let duration = match parse_break_start_time(&time) {
-        Some(d) if d > Duration::ZERO && d <= MAX_BREAK_DURATION => d,
+    let (duration, clock_time_label) = match parse_break_start_time(&time) {
+        Some((d, label)) if d > Duration::ZERO && d <= MAX_BREAK_DURATION => (d, label),
         Some(_) => {
             CreateEmbed::new()
                 .color(Color::DARK_RED)
@@ -146,6 +149,7 @@ pub async fn start(
         original_duration: duration,
         extension: Mutex::new(Duration::ZERO),
         author_mention: author_mention.clone(),
+        clock_time_label,
     });
 
     ctx.data()
@@ -367,9 +371,9 @@ pub async fn extend(
 }
 
 /// Parse a break start time: relative duration (`5m`, `1h 30s`) or clock time
-/// (`14:00`). Clock times resolve to the duration until that time today (or
-/// tomorrow if already past).
-fn parse_break_start_time(text: &str) -> Option<Duration> {
+/// (`14:00`). Returns `(duration, clock_label)` — `clock_label` is `Some("17:10")`
+/// when a clock time was supplied, `None` for relative durations.
+fn parse_break_start_time(text: &str) -> Option<(Duration, Option<String>)> {
     let text = text.trim();
 
     // Relative duration: 10m, 1h, 30s, 1h 30m, …
@@ -377,7 +381,7 @@ fn parse_break_start_time(text: &str) -> Option<Duration> {
         if d == Duration::ZERO {
             return None;
         }
-        return Some(d);
+        return Some((d, None));
     }
 
     // Clock time: HH:MM or H:MM — break ends at that wall-clock time.
@@ -402,7 +406,8 @@ fn parse_break_start_time(text: &str) -> Option<Duration> {
         return None;
     }
 
-    Some(Duration::from_secs(until_secs))
+    let label = format!("{:02}:{:02}", hour, minute);
+    Some((Duration::from_secs(until_secs), Some(label)))
 }
 
 /// Parse a relative-only break extension: `5m`, `1h 30s`, `90s`, etc.
@@ -438,12 +443,18 @@ fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {
         Color::DARK_GOLD
     };
 
+    let opening = match &state.clock_time_label {
+        Some(label) => format!("{} started a break until **{}**.", state.author_mention, label),
+        None => format!(
+            "{} started a break of **{}**.",
+            state.author_mention,
+            humanize_duration(state.original_duration)
+        ),
+    };
+
     let mut description = format!(
-        "{} started a break of **{}**.\n\n\
-         Time remaining: **{}**\n\
-         Ends at: `{}`",
-        state.author_mention,
-        humanize_duration(state.original_duration),
+        "{}\n\nTime remaining: **{}**\nEnds at: `{}`",
+        opening,
         humanize_duration(remaining),
         format_wall_clock(state.ends_at_wall()),
     );

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -4,7 +4,7 @@ use crate::embeds::bot_embeds::BotEmbed;
 use crate::player::notifier::{get_current_time, parse_duration_from_string};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
-use crate::service::gather_service::{self, GatherState};
+use crate::service::gather_service::{self, humanize_duration, GatherState};
 use serenity::all::{
     ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
     CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
@@ -288,6 +288,8 @@ pub async fn start(
         text_channel_id,
         voice_channel_id,
         author_id,
+        author_mention,
+        String::new(),
         gather_state,
         Duration::ZERO,
     )
@@ -454,24 +456,23 @@ fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {
     };
 
     let opening = match &state.clock_time_label {
-        Some(label) => format!("{} started a break until **{}**.", state.author_mention, label),
+        Some(label) => format!("{} started a break until {}.", state.author_mention, label),
         None => format!(
-            "{} started a break of **{}**.",
+            "{} started a break of {}.",
             state.author_mention,
             humanize_duration(state.original_duration)
         ),
     };
 
     let mut description = format!(
-        "{}\n\nTime remaining: **{}**\nEnds at: `{}`",
+        "{}\n\nTime remaining: {}",
         opening,
         humanize_duration(remaining),
-        format_wall_clock(state.ends_at_wall()),
     );
 
     if extension > Duration::ZERO {
         description.push_str(&format!(
-            "\nExtended by: **{}** (total **{}**)",
+            "\nExtended by: {} (total {})",
             humanize_duration(extension),
             humanize_duration(total),
         ));
@@ -492,29 +493,6 @@ fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {
     }
 
     builder
-}
-
-fn humanize_duration(d: Duration) -> String {
-    let total = d.as_secs();
-    if total == 0 {
-        return "0 seconds".to_string();
-    }
-
-    let h = total / 3600;
-    let m = (total % 3600) / 60;
-    let s = total % 60;
-
-    let mut parts: Vec<String> = Vec::new();
-    if h > 0 {
-        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
-    }
-    if m > 0 {
-        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
-    }
-    if s > 0 {
-        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
-    }
-    parts.join(" ")
 }
 
 fn format_wall_clock(t: OffsetDateTime) -> String {

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 use time::OffsetDateTime;
 
 const BTN_BREAK_CANCEL: &str = "break_cancel";
+const BTN_BREAK_SKIP: &str = "break_skip";
 const MAX_BREAK_DURATION: Duration = Duration::from_secs(60 * 60 * 4);
 const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -210,25 +211,30 @@ pub async fn start(
             .await;
 
         if let Some(ic) = interaction {
-            if ic.data.custom_id == BTN_BREAK_CANCEL {
-                if ic.user.id != author_id {
-                    ic.create_response(
-                        ctx.http(),
-                        CreateInteractionResponse::Message(
-                            CreateInteractionResponseMessage::new()
-                                .content("Only the person who started the break can cancel it.")
-                                .ephemeral(true),
-                        ),
-                    )
-                    .await
-                    .ok();
-                    continue;
+            match ic.data.custom_id.as_str() {
+                BTN_BREAK_CANCEL | BTN_BREAK_SKIP => {
+                    if ic.user.id != author_id {
+                        ic.create_response(
+                            ctx.http(),
+                            CreateInteractionResponse::Message(
+                                CreateInteractionResponseMessage::new()
+                                    .content("Only the person who started the break can do that.")
+                                    .ephemeral(true),
+                            ),
+                        )
+                        .await
+                        .ok();
+                        continue;
+                    }
+                    ic.create_response(ctx.http(), CreateInteractionResponse::Acknowledge)
+                        .await
+                        .ok();
+                    if ic.data.custom_id == BTN_BREAK_CANCEL {
+                        cancelled = true;
+                    }
+                    break;
                 }
-                ic.create_response(ctx.http(), CreateInteractionResponse::Acknowledge)
-                    .await
-                    .ok();
-                cancelled = true;
-                break;
+                _ => {}
             }
         }
 
@@ -422,12 +428,16 @@ fn parse_break_duration(text: &str) -> Option<Duration> {
 }
 
 fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {
-    vec![CreateActionRow::Buttons(vec![CreateButton::new(
-        BTN_BREAK_CANCEL,
-    )
-    .label("Cancel")
-    .style(ButtonStyle::Danger)
-    .disabled(disabled)])]
+    vec![CreateActionRow::Buttons(vec![
+        CreateButton::new(BTN_BREAK_SKIP)
+            .label("Skip to gathering")
+            .style(ButtonStyle::Primary)
+            .disabled(disabled),
+        CreateButton::new(BTN_BREAK_CANCEL)
+            .label("Cancel")
+            .style(ButtonStyle::Danger)
+            .disabled(disabled),
+    ])]
 }
 
 fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -65,7 +65,7 @@ pub async fn start(
     ctx: Context<'_>,
     #[description = "Break end time or duration, e.g. `5m`, `1h 30s`, `14:00`."] time: String,
 ) -> Result<(), MusicBotError> {
-    let duration = match parse_break_duration(&time) {
+    let duration = match parse_break_start_time(&time) {
         Some(d) if d > Duration::ZERO && d <= MAX_BREAK_DURATION => d,
         Some(_) => {
             CreateEmbed::new()
@@ -366,7 +366,10 @@ pub async fn extend(
     Ok(())
 }
 
-fn parse_break_duration(text: &str) -> Option<Duration> {
+/// Parse a break start time: relative duration (`5m`, `1h 30s`) or clock time
+/// (`14:00`). Clock times resolve to the duration until that time today (or
+/// tomorrow if already past).
+fn parse_break_start_time(text: &str) -> Option<Duration> {
     let text = text.trim();
 
     // Relative duration: 10m, 1h, 30s, 1h 30m, …
@@ -400,6 +403,17 @@ fn parse_break_duration(text: &str) -> Option<Duration> {
     }
 
     Some(Duration::from_secs(until_secs))
+}
+
+/// Parse a relative-only break extension: `5m`, `1h 30s`, `90s`, etc.
+/// Clock times are intentionally not supported here — an extension must be an
+/// amount of additional time, not an absolute end time.
+fn parse_break_duration(text: &str) -> Option<Duration> {
+    let d = parse_duration_from_string(text.trim())?;
+    if d == Duration::ZERO {
+        return None;
+    }
+    Some(d)
 }
 
 fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -4,7 +4,7 @@ use crate::embeds::bot_embeds::BotEmbed;
 use crate::player::notifier::{get_current_time, parse_duration_from_string};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
-use crate::service::gather_service::{self, GatherState, PREGATHER_DURATION};
+use crate::service::gather_service::{self, GatherState};
 use serenity::all::{
     ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
     CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
@@ -63,7 +63,7 @@ pub async fn r#break(_ctx: Context<'_>) -> Result<(), MusicBotError> {
 #[poise::command(slash_command, prefix_command, check = "check_author_in_voice_channel")]
 pub async fn start(
     ctx: Context<'_>,
-    #[description = "Break length, e.g. `5m`, `1h 30s`, `90s`."] time: String,
+    #[description = "Break end time or duration, e.g. `5m`, `1h 30s`, `14:00`."] time: String,
 ) -> Result<(), MusicBotError> {
     let duration = match parse_break_duration(&time) {
         Some(d) if d > Duration::ZERO && d <= MAX_BREAK_DURATION => d,
@@ -83,7 +83,10 @@ pub async fn start(
             CreateEmbed::new()
                 .color(Color::DARK_RED)
                 .title("🚫  Invalid break duration")
-                .description("Use a relative duration like `5m`, `1h 30s`, or `90s`.")
+                .description(
+                    "Use a relative duration like `5m`, `1h 30s`, or `90s`, \
+                     or a clock time like `10:00` or `14:30`.",
+                )
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -268,6 +271,7 @@ pub async fn start(
         .await
         .insert(guild_id, Arc::clone(&gather_state));
 
+    // Skip the pre-gather countdown — break already announced and pinged everyone.
     gather_service::start_gather(
         ctx.serenity_context(),
         guild_id,
@@ -275,7 +279,7 @@ pub async fn start(
         voice_channel_id,
         author_id,
         gather_state,
-        PREGATHER_DURATION,
+        Duration::ZERO,
     )
     .await?;
 
@@ -363,11 +367,39 @@ pub async fn extend(
 }
 
 fn parse_break_duration(text: &str) -> Option<Duration> {
-    let d = parse_duration_from_string(text.trim())?;
-    if d == Duration::ZERO {
+    let text = text.trim();
+
+    // Relative duration: 10m, 1h, 30s, 1h 30m, …
+    if let Some(d) = parse_duration_from_string(text) {
+        if d == Duration::ZERO {
+            return None;
+        }
+        return Some(d);
+    }
+
+    // Clock time: HH:MM or H:MM — break ends at that wall-clock time.
+    let (h_str, m_str) = text.split_once(':')?;
+    let hour: u8 = h_str.trim().parse().ok()?;
+    let minute: u8 = m_str.trim().parse().ok()?;
+    if hour > 23 || minute > 59 {
         return None;
     }
-    Some(d)
+
+    let now = get_current_time();
+    let now_secs = now.hour() as u64 * 3600 + now.minute() as u64 * 60 + now.second() as u64;
+    let target_secs = hour as u64 * 3600 + minute as u64 * 60;
+
+    let until_secs = if target_secs > now_secs {
+        target_secs - now_secs
+    } else {
+        86400 - now_secs + target_secs
+    };
+
+    if until_secs == 0 {
+        return None;
+    }
+
+    Some(Duration::from_secs(until_secs))
 }
 
 fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -456,31 +456,31 @@ fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {
     };
 
     let opening = match &state.clock_time_label {
-        Some(label) => format!("{} started a break until {}.", state.author_mention, label),
+        Some(label) => format!("{} started a break until **{}**.", state.author_mention, label),
         None => format!(
-            "{} started a break of {}.",
+            "{} started a break of **{}**.",
             state.author_mention,
             humanize_duration(state.original_duration)
         ),
     };
 
     let mut description = format!(
-        "{}\n\nTime remaining: {}",
+        "{}\n\nTime remaining: **{}**",
         opening,
         humanize_duration(remaining),
     );
 
     if extension > Duration::ZERO {
         description.push_str(&format!(
-            "\nExtended by: {} (total {})",
+            "\nExtended by: **{}** (total **{}**)",
             humanize_duration(extension),
             humanize_duration(total),
         ));
     }
 
     description.push_str(
-        "\n\nWhen the timer ends, everyone still in voice will be gathered \
-         automatically — late arrivals will be tracked.",
+        "\n\nWhen the timer ends, everyone still in voice will be gathered automatically
+        \n— late arrivals will be tracked.",
     );
 
     let mut builder = CreateEmbed::new()

--- a/src/commands/utility/cmd_gather.rs
+++ b/src/commands/utility/cmd_gather.rs
@@ -4,7 +4,7 @@ use crate::embeds::bot_embeds::BotEmbed;
 use crate::player::notifier::{get_current_time, parse_duration_from_string};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
-use crate::service::gather_service::{self, GatherState, PREGATHER_DURATION};
+use crate::service::gather_service::{self, humanize_duration, GatherState, PREGATHER_DURATION};
 use serenity::all::{
     ChannelId, Color, CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage,
     GuildId, Mentionable, User,
@@ -44,9 +44,9 @@ pub async fn start(
             }
         };
 
-    let pregather_duration = match time {
-        Some(ref t) => match parse_pregather_duration(t.trim()) {
-            Some(d) => d,
+    let (pregather_duration, schedule_label) = match time {
+        Some(ref t) => match parse_pregather_time(t.trim()) {
+            Some(pair) => pair,
             None => {
                 CreateEmbed::new()
                     .color(Color::DARK_RED)
@@ -60,7 +60,7 @@ pub async fn start(
                 return Ok(());
             }
         },
-        None => PREGATHER_DURATION,
+        None => (PREGATHER_DURATION, format!("in {}", humanize_duration(PREGATHER_DURATION))),
     };
 
     {
@@ -106,6 +106,8 @@ pub async fn start(
         ctx.channel_id(),
         voice_channel_id,
         ctx.author().id,
+        ctx.author().mention().to_string(),
+        schedule_label,
         state,
         pregather_duration,
     )
@@ -183,13 +185,13 @@ pub async fn expect(
 }
 
 /// Parse a pregather countdown from either a relative duration (`10m`, `1h 30m`)
-/// or a clock time (`10:00`, `14:30`).  Clock times use the bot's local timezone
-/// (CET/CEST); if the target time has already passed today, the countdown targets
-/// the same time tomorrow.  Returns `None` for unparseable or zero-length input.
-fn parse_pregather_duration(text: &str) -> Option<Duration> {
+/// or a clock time (`10:00`, `14:30`). Returns `(duration, display_label)` where
+/// the label is "in X minutes" for relative or "at HH:MM" for clock times.
+fn parse_pregather_time(text: &str) -> Option<(Duration, String)> {
     // Relative duration: 10m, 1h, 30s, 1h 30m, …
     if let Some(d) = parse_duration_from_string(text) {
-        return Some(d);
+        let label = format!("in {}", humanize_duration(d));
+        return Some((d, label));
     }
 
     // Clock time: HH:MM or H:MM
@@ -215,5 +217,6 @@ fn parse_pregather_duration(text: &str) -> Option<Duration> {
         return None;
     }
 
-    Some(Duration::from_secs(until_secs))
+    let label = format!("at {:02}:{:02}", hour, minute);
+    Some((Duration::from_secs(until_secs), label))
 }

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -70,126 +70,141 @@ pub async fn start_gather(
         ));
     }
 
-    // Ping all current voice members above the embed.
-    let voice_mentions: String = initial_voice_ids
-        .iter()
-        .map(|id| id.mention().to_string())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let _ = text_channel_id
-        .send_message(&serenity_ctx.http, CreateMessage::new().content(voice_mentions))
-        .await;
-
     // ── Phase 1: pre-gather countdown ──────────────────────────────────────
-    let pregather_ends_at = Instant::now() + pregather_duration;
+    // Skipped when pregather_duration is zero (e.g. auto-gather after a break).
 
-    let mut msg: Message = text_channel_id
-        .send_message(
-            &serenity_ctx.http,
-            CreateMessage::new()
-                .embed(build_pregather_embed(pregather_ends_at, None))
-                .components(pregather_buttons(false)),
-        )
-        .await
-        .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
+    let mut msg: Message;
 
-    let pregather_cancelled = 'pregather: loop {
-        let now = Instant::now();
-        if now >= pregather_ends_at {
-            break false;
-        }
-
-        let wait = pregather_ends_at
-            .saturating_duration_since(now)
-            .min(MIN_EDIT_INTERVAL);
-
-        match msg
-            .await_component_interaction(shard.clone())
-            .timeout(wait)
-            .await
-        {
-            Some(ic) => match ic.data.custom_id.as_str() {
-                BTN_CANCEL => {
-                    if ic.user.id != author_id {
-                        ic.create_response(
-                            &serenity_ctx.http,
-                            CreateInteractionResponse::Message(
-                                CreateInteractionResponseMessage::new()
-                                    .content(
-                                        "Only the person who started the gathering can cancel it.",
-                                    )
-                                    .ephemeral(true),
-                            ),
-                        )
-                        .await
-                        .ok();
-                        continue 'pregather;
-                    }
-                    ic.create_response(
-                        &serenity_ctx.http,
-                        CreateInteractionResponse::Acknowledge,
-                    )
-                    .await
-                    .ok();
-                    break 'pregather true;
-                }
-                BTN_FORCE_START => {
-                    if ic.user.id != author_id {
-                        ic.create_response(
-                            &serenity_ctx.http,
-                            CreateInteractionResponse::Message(
-                                CreateInteractionResponseMessage::new()
-                                    .content(
-                                        "Only the person who started the gathering can skip the countdown.",
-                                    )
-                                    .ephemeral(true),
-                            ),
-                        )
-                        .await
-                        .ok();
-                        continue 'pregather;
-                    }
-                    ic.create_response(
-                        &serenity_ctx.http,
-                        CreateInteractionResponse::Acknowledge,
-                    )
-                    .await
-                    .ok();
-                    break 'pregather false;
-                }
-                _ => {
-                    ic.create_response(
-                        &serenity_ctx.http,
-                        CreateInteractionResponse::Acknowledge,
-                    )
-                    .await
-                    .ok();
-                }
-            },
-            None => {
-                // Timeout: refresh the countdown display.
-                let _ = msg
-                    .edit(
-                        &serenity_ctx.http,
-                        EditMessage::new()
-                            .embed(build_pregather_embed(pregather_ends_at, None))
-                            .components(pregather_buttons(false)),
-                    )
-                    .await;
-            }
-        }
-    };
-
-    if pregather_cancelled {
-        let _ = msg
-            .edit(
-                &serenity_ctx.http,
-                EditMessage::new()
-                    .embed(build_pregather_embed(pregather_ends_at, Some("Cancelled.")))
-                    .components(Vec::new()),
-            )
+    if pregather_duration > Duration::ZERO {
+        // Ping all current voice members above the embed.
+        let voice_mentions: String = initial_voice_ids
+            .iter()
+            .map(|id| id.mention().to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let _ = text_channel_id
+            .send_message(&serenity_ctx.http, CreateMessage::new().content(voice_mentions))
             .await;
-        return Ok(());
+
+        let pregather_ends_at = Instant::now() + pregather_duration;
+
+        msg = text_channel_id
+            .send_message(
+                &serenity_ctx.http,
+                CreateMessage::new()
+                    .embed(build_pregather_embed(pregather_ends_at, None))
+                    .components(pregather_buttons(false)),
+            )
+            .await
+            .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
+
+        let pregather_cancelled = 'pregather: loop {
+            let now = Instant::now();
+            if now >= pregather_ends_at {
+                break false;
+            }
+
+            let wait = pregather_ends_at
+                .saturating_duration_since(now)
+                .min(MIN_EDIT_INTERVAL);
+
+            match msg
+                .await_component_interaction(shard.clone())
+                .timeout(wait)
+                .await
+            {
+                Some(ic) => match ic.data.custom_id.as_str() {
+                    BTN_CANCEL => {
+                        if ic.user.id != author_id {
+                            ic.create_response(
+                                &serenity_ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content(
+                                            "Only the person who started the gathering can cancel it.",
+                                        )
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await
+                            .ok();
+                            continue 'pregather;
+                        }
+                        ic.create_response(
+                            &serenity_ctx.http,
+                            CreateInteractionResponse::Acknowledge,
+                        )
+                        .await
+                        .ok();
+                        break 'pregather true;
+                    }
+                    BTN_FORCE_START => {
+                        if ic.user.id != author_id {
+                            ic.create_response(
+                                &serenity_ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new()
+                                        .content(
+                                            "Only the person who started the gathering can skip the countdown.",
+                                        )
+                                        .ephemeral(true),
+                                ),
+                            )
+                            .await
+                            .ok();
+                            continue 'pregather;
+                        }
+                        ic.create_response(
+                            &serenity_ctx.http,
+                            CreateInteractionResponse::Acknowledge,
+                        )
+                        .await
+                        .ok();
+                        break 'pregather false;
+                    }
+                    _ => {
+                        ic.create_response(
+                            &serenity_ctx.http,
+                            CreateInteractionResponse::Acknowledge,
+                        )
+                        .await
+                        .ok();
+                    }
+                },
+                None => {
+                    // Timeout: refresh the countdown display.
+                    let _ = msg
+                        .edit(
+                            &serenity_ctx.http,
+                            EditMessage::new()
+                                .embed(build_pregather_embed(pregather_ends_at, None))
+                                .components(pregather_buttons(false)),
+                        )
+                        .await;
+                }
+            }
+        };
+
+        if pregather_cancelled {
+            let _ = msg
+                .edit(
+                    &serenity_ctx.http,
+                    EditMessage::new()
+                        .embed(build_pregather_embed(pregather_ends_at, Some("Cancelled.")))
+                        .components(Vec::new()),
+                )
+                .await;
+            return Ok(());
+        }
+    } else {
+        // No countdown: create a placeholder message that phase 2 will immediately replace.
+        msg = text_channel_id
+            .send_message(
+                &serenity_ctx.http,
+                CreateMessage::new().content("Gathering starting…"),
+            )
+            .await
+            .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
     }
 
     // ── Phase 2: gathering check-in ────────────────────────────────────────
@@ -471,6 +486,19 @@ async fn handle_interaction(
             *last_edit = Instant::now();
         }
         BTN_TOGGLE_SILENT => {
+            if ic.user.id != author_id {
+                ic.create_response(
+                    &serenity_ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("Only the person who started the gathering can mute pings.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await
+                .ok();
+                return;
+            }
             let new_silent = {
                 let mut s = state.silent.lock().unwrap();
                 *s = !*s;

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -57,6 +57,8 @@ pub async fn start_gather(
     text_channel_id: ChannelId,
     voice_channel_id: ChannelId,
     author_id: UserId,
+    author_mention: String,
+    schedule_label: String,
     state: Arc<GatherState>,
     pregather_duration: Duration,
 ) -> Result<(), MusicBotError> {
@@ -95,7 +97,7 @@ pub async fn start_gather(
             .send_message(
                 &serenity_ctx.http,
                 CreateMessage::new()
-                    .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, None))
+                    .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, &author_mention, &schedule_label, None))
                     .components(pregather_buttons(false)),
             )
             .await
@@ -180,7 +182,7 @@ pub async fn start_gather(
                         .edit(
                             &serenity_ctx.http,
                             EditMessage::new()
-                                .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, None))
+                                .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, &author_mention, &schedule_label, None))
                                 .components(pregather_buttons(false)),
                         )
                         .await;
@@ -193,7 +195,7 @@ pub async fn start_gather(
                 .edit(
                     &serenity_ctx.http,
                     EditMessage::new()
-                        .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, Some("Cancelled.")))
+                        .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, &author_mention, &schedule_label, Some("Cancelled.")))
                         .components(Vec::new()),
                 )
                 .await;
@@ -656,20 +658,49 @@ fn pregather_buttons(disabled: bool) -> Vec<CreateActionRow> {
     ])]
 }
 
-fn build_pregather_embed(ends_at: Instant, ends_at_wall: OffsetDateTime, footer: Option<&str>) -> CreateEmbed {
+fn build_pregather_embed(
+    ends_at: Instant,
+    ends_at_wall: OffsetDateTime,
+    author_mention: &str,
+    schedule_label: &str,
+    footer: Option<&str>,
+) -> CreateEmbed {
     let remaining = ends_at.saturating_duration_since(Instant::now());
     let mut builder = CreateEmbed::new()
         .color(Color::DARK_BLUE)
         .title("📣  Voice Channel Gathering")
         .description(format!(
-            "Starting in **{}** — join the voice channel now!\n\nStarts at: `{}`",
-            format_mmss(remaining),
+            "{} scheduled gathering {}.\n\nTime remaining: {}\nStarts at: `{}`\n\nWhen the timer ends, everyone still in voice will be gathered automatically — late arrivals will be tracked.",
+            author_mention,
+            schedule_label,
+            humanize_duration(remaining),
             format_wall_clock(ends_at_wall),
         ));
     if let Some(text) = footer {
         builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
     }
     builder
+}
+
+pub fn humanize_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    if total == 0 {
+        return "0 seconds".to_string();
+    }
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    let mut parts: Vec<String> = Vec::new();
+    if h > 0 {
+        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
+    }
+    if m > 0 {
+        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
+    }
+    if s > 0 {
+        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
+    }
+    parts.join(" ")
 }
 
 fn format_wall_clock(t: OffsetDateTime) -> String {

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -1,4 +1,5 @@
 use crate::bot::MusicBotError;
+use crate::player::notifier::get_current_time;
 use serenity::all::{
     ButtonStyle, ChannelId, Color, ComponentInteractionCollector, CreateActionRow, CreateButton,
     CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage,
@@ -10,6 +11,7 @@ use serenity::prelude::Context as SerenityContext;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use time::OffsetDateTime;
 
 /// Shared state for an active gathering.
 pub struct GatherState {
@@ -87,12 +89,13 @@ pub async fn start_gather(
             .await;
 
         let pregather_ends_at = Instant::now() + pregather_duration;
+        let pregather_ends_at_wall = get_current_time() + pregather_duration;
 
         msg = text_channel_id
             .send_message(
                 &serenity_ctx.http,
                 CreateMessage::new()
-                    .embed(build_pregather_embed(pregather_ends_at, None))
+                    .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, None))
                     .components(pregather_buttons(false)),
             )
             .await
@@ -177,7 +180,7 @@ pub async fn start_gather(
                         .edit(
                             &serenity_ctx.http,
                             EditMessage::new()
-                                .embed(build_pregather_embed(pregather_ends_at, None))
+                                .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, None))
                                 .components(pregather_buttons(false)),
                         )
                         .await;
@@ -190,7 +193,7 @@ pub async fn start_gather(
                 .edit(
                     &serenity_ctx.http,
                     EditMessage::new()
-                        .embed(build_pregather_embed(pregather_ends_at, Some("Cancelled.")))
+                        .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, Some("Cancelled.")))
                         .components(Vec::new()),
                 )
                 .await;
@@ -653,19 +656,24 @@ fn pregather_buttons(disabled: bool) -> Vec<CreateActionRow> {
     ])]
 }
 
-fn build_pregather_embed(ends_at: Instant, footer: Option<&str>) -> CreateEmbed {
+fn build_pregather_embed(ends_at: Instant, ends_at_wall: OffsetDateTime, footer: Option<&str>) -> CreateEmbed {
     let remaining = ends_at.saturating_duration_since(Instant::now());
     let mut builder = CreateEmbed::new()
         .color(Color::DARK_BLUE)
         .title("📣  Voice Channel Gathering")
         .description(format!(
-            "Starting in **{}** — join the voice channel now!",
+            "Starting in **{}** — join the voice channel now!\n\nStarts at: `{}`",
             format_mmss(remaining),
+            format_wall_clock(ends_at_wall),
         ));
     if let Some(text) = footer {
         builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
     }
     builder
+}
+
+fn format_wall_clock(t: OffsetDateTime) -> String {
+    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
 }
 
 fn buttons(disabled: bool, silent: bool) -> Vec<CreateActionRow> {

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -670,7 +670,11 @@ fn build_pregather_embed(
         .color(Color::DARK_BLUE)
         .title("📣  Voice Channel Gathering")
         .description(format!(
-            "{} scheduled gathering {}.\n\nTime remaining: {}\nStarts at: `{}`\n\nWhen the timer ends, everyone still in voice will be gathered automatically — late arrivals will be tracked.",
+            "{} scheduled gathering {}.
+            \n\nTime remaining: **{}**
+            \nStarts at: `{}`
+            \n\nWhen the timer ends, everyone still in voice will be gathered automatically 
+            \n— late arrivals will be tracked.",
             author_mention,
             schedule_label,
             humanize_duration(remaining),

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -197,11 +197,21 @@ pub async fn start_gather(
             return Ok(());
         }
     } else {
-        // No countdown: create a placeholder message that phase 2 will immediately replace.
+        // No countdown: ping voice members so they're notified gathering is starting.
+        // Phase 2 will edit this message into the check-in embed.
+        let voice_mentions: String = initial_voice_ids
+            .iter()
+            .map(|id| id.mention().to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
         msg = text_channel_id
             .send_message(
                 &serenity_ctx.http,
-                CreateMessage::new().content("Gathering starting…"),
+                CreateMessage::new().content(if voice_mentions.is_empty() {
+                    "Gathering starting…".to_string()
+                } else {
+                    voice_mentions
+                }),
             )
             .await
             .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
@@ -233,6 +243,7 @@ pub async fn start_gather(
         .edit(
             &serenity_ctx.http,
             EditMessage::new()
+                .content("")
                 .embed(build_embed(
                     serenity_ctx,
                     guild_id,
@@ -304,11 +315,6 @@ pub async fn start_gather(
         }
 
         let now = Instant::now();
-
-        // Track late joiners from voice channel.
-        for id in current_voice_members(serenity_ctx, guild_id, voice_channel_id, bot_id) {
-            expected.insert(id);
-        }
 
         // Merge users added via /gather expect.
         {


### PR DESCRIPTION
## Summary
This PR enhances the gathering system to support auto-gather after breaks and adds clock time parsing for break durations. It also improves permission checks for gathering controls.

## Key Changes

- **Conditional pre-gather countdown**: The pre-gather phase now skips when `pregather_duration` is zero, allowing auto-gather after breaks without an additional countdown. A placeholder message is created instead to be replaced by phase 2.

- **Clock time support for breaks**: The `parse_break_duration()` function now accepts both relative durations (e.g., `5m`, `1h 30s`) and clock times (e.g., `14:00`, `10:30`). Clock times calculate the duration until that wall-clock time, wrapping to the next day if necessary.

- **Permission check for silent toggle**: Added authorization check to the `BTN_TOGGLE_SILENT` button handler to ensure only the gathering author can mute pings, consistent with other gathering controls.

- **Updated break command**: 
  - Removed the `PREGATHER_DURATION` constant import and now passes `Duration::ZERO` to `start_gather()` to skip the countdown
  - Updated command description and error message to document clock time support
  - Adjusted help text to guide users on both duration and clock time formats

## Implementation Details

- The pre-gather phase is now wrapped in an `if pregather_duration > Duration::ZERO` block, with an else branch creating a minimal placeholder message
- Clock time parsing validates hour (0-23) and minute (0-59) ranges and handles day wraparound
- The `msg` variable is declared before the conditional to be available for phase 2 regardless of which branch executes

https://claude.ai/code/session_01SM9AtiJTmBL2wuH7zaaEfk