### PR TITLE
Refactor embed and service logic into dedicated modules

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,6 +1,6 @@
 use crate::commands;
-use crate::commands::utility::cmd_break::BreakState;
 use crate::commands::{music, reputation, utility};
+use crate::service::break_service::BreakState;
 use crate::service::gather_service::GatherState;
 use crate::handlers::error_handler;
 use crate::player::notifier::{Notifier, NotifierError};

--- a/src/commands/utility/cmd_break.rs
+++ b/src/commands/utility/cmd_break.rs
@@ -1,55 +1,20 @@
 use crate::bot::{Context, MusicBotError};
 use crate::checks::channel_checks::check_author_in_voice_channel;
 use crate::embeds::bot_embeds::BotEmbed;
-use crate::player::notifier::{get_current_time, parse_duration_from_string};
+use crate::embeds::break_embed::BreakEmbed;
+use crate::player::notifier::get_current_time;
+use crate::service::break_service::{
+    self, parse_break_duration, parse_break_start_time, BreakState, MAX_BREAK_DURATION,
+};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
-use crate::service::gather_service::{self, humanize_duration, GatherState};
+use crate::service::gather_service::{self, GatherState};
 use serenity::all::{
-    ButtonStyle, ChannelId, Color, CreateActionRow, CreateButton, CreateEmbed,
-    CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage, EditMessage,
-    GuildId, Mentionable, Message, UserId,
+    ChannelId, CreateInteractionResponse, CreateInteractionResponseMessage, GuildId, Mentionable,
+    UserId,
 };
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use time::OffsetDateTime;
-
-const BTN_BREAK_CANCEL: &str = "break_cancel";
-const BTN_BREAK_SKIP: &str = "break_skip";
-const MAX_BREAK_DURATION: Duration = Duration::from_secs(60 * 60 * 4);
-const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
-
-/// Shared mutable state for the active break in a guild. Mutated by
-/// `/break extend` and read by the running `/break start` loop.
-pub struct BreakState {
-    pub author_id: UserId,
-    pub started_at_instant: Instant,
-    pub started_at_wall: OffsetDateTime,
-    pub original_duration: Duration,
-    pub extension: Mutex<Duration>,
-    pub author_mention: String,
-    /// Set when the break was started with a clock time (e.g. "17:10") rather
-    /// than a relative duration. Controls the embed wording.
-    pub clock_time_label: Option<String>,
-}
-
-impl BreakState {
-    fn total_duration(&self) -> Duration {
-        self.original_duration + *self.extension.lock().unwrap()
-    }
-
-    fn ends_at_instant(&self) -> Instant {
-        self.started_at_instant + self.total_duration()
-    }
-
-    fn ends_at_wall(&self) -> OffsetDateTime {
-        self.started_at_wall + self.total_duration()
-    }
-
-    fn extension_total(&self) -> Duration {
-        *self.extension.lock().unwrap()
-    }
-}
 
 /// Take a break — when the timer runs out, everyone in voice is auto-gathered.
 #[poise::command(
@@ -72,25 +37,15 @@ pub async fn start(
     let (duration, clock_time_label) = match parse_break_start_time(&time) {
         Some((d, label)) if d > Duration::ZERO && d <= MAX_BREAK_DURATION => (d, label),
         Some(_) => {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  Break too long")
-                .description(format!(
-                    "Maximum break length is {}.",
-                    humanize_duration(MAX_BREAK_DURATION)
-                ))
+            BreakEmbed::TooLong { max: MAX_BREAK_DURATION }
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
         }
         None => {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  Invalid break duration")
-                .description(
-                    "Use a relative duration like `5m`, `1h 30s`, or `90s`, \
-                     or a clock time like `10:00` or `14:30`.",
-                )
+            BreakEmbed::InvalidDuration
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -116,10 +71,8 @@ pub async fn start(
     {
         let breaks = ctx.data().breaks.read().await;
         if breaks.contains_key(&guild_id) {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  Break already running")
-                .description("There's already an active break in this guild — extend it with `/break extend <time>` instead.")
+            BreakEmbed::AlreadyRunning
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -159,113 +112,14 @@ pub async fn start(
         .await
         .insert(guild_id, Arc::clone(&state));
 
-    // Ping all voice members in a separate message above the embed.
-    let bot_id = ctx.serenity_context().cache.current_user().id;
-    let voice_mentions: String = ctx
-        .serenity_context()
-        .cache
-        .guild(guild_id)
-        .as_ref()
-        .map(|g| {
-            g.voice_states
-                .values()
-                .filter(|vs| vs.channel_id == Some(voice_channel_id) && vs.user_id != bot_id)
-                .map(|vs| vs.user_id.mention().to_string())
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .unwrap_or_default();
-    if !voice_mentions.is_empty() {
-        let _ = text_channel_id
-            .send_message(&ctx.http(), CreateMessage::new().content(voice_mentions))
-            .await;
-    }
-
-    let mut msg: Message = text_channel_id
-        .send_message(
-            &ctx.http(),
-            CreateMessage::new()
-                .embed(build_break_embed(&state, None))
-                .components(break_buttons(false)),
-        )
-        .await
-        .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
-
-    let mut cancelled = false;
-    let mut last_edit = Instant::now();
-    let shard = ctx.serenity_context().shard.clone();
-
-    loop {
-        let now = Instant::now();
-        let ends_at = state.ends_at_instant();
-        if now >= ends_at {
-            break;
-        }
-
-        let remaining = ends_at.saturating_duration_since(now);
-        let wait = remaining.min(MIN_EDIT_INTERVAL);
-
-        let interaction = msg
-            .await_component_interaction(shard.clone())
-            .timeout(wait)
-            .await;
-
-        if let Some(ic) = interaction {
-            match ic.data.custom_id.as_str() {
-                BTN_BREAK_CANCEL | BTN_BREAK_SKIP => {
-                    if ic.user.id != author_id {
-                        ic.create_response(
-                            ctx.http(),
-                            CreateInteractionResponse::Message(
-                                CreateInteractionResponseMessage::new()
-                                    .content("Only the person who started the break can do that.")
-                                    .ephemeral(true),
-                            ),
-                        )
-                        .await
-                        .ok();
-                        continue;
-                    }
-                    ic.create_response(ctx.http(), CreateInteractionResponse::Acknowledge)
-                        .await
-                        .ok();
-                    if ic.data.custom_id == BTN_BREAK_CANCEL {
-                        cancelled = true;
-                    }
-                    break;
-                }
-                _ => {}
-            }
-        }
-
-        if Instant::now() < last_edit + MIN_EDIT_INTERVAL {
-            continue;
-        }
-        last_edit = Instant::now();
-        let _ = msg
-            .edit(
-                ctx.http(),
-                EditMessage::new()
-                    .embed(build_break_embed(&state, None))
-                    .components(break_buttons(false)),
-            )
-            .await;
-    }
-
-    let footer = if cancelled {
-        "Break cancelled."
-    } else {
-        "Break is over — starting gathering."
-    };
-
-    let _ = msg
-        .edit(
-            ctx.http(),
-            EditMessage::new()
-                .embed(build_break_embed(&state, Some(footer)))
-                .components(Vec::new()),
-        )
-        .await;
+    let cancelled = break_service::run_break(
+        ctx.serenity_context(),
+        guild_id,
+        text_channel_id,
+        voice_channel_id,
+        Arc::clone(&state),
+    )
+    .await?;
 
     // Drop the break state before handing off to the gather flow.
     ctx.data().breaks.write().await.remove(&guild_id);
@@ -309,10 +163,8 @@ pub async fn extend(
     let extra = match parse_break_duration(&time) {
         Some(d) if d > Duration::ZERO => d,
         _ => {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  Invalid extension")
-                .description("Use a relative duration like `5m`, `1h 30s`, or `90s`.")
+            BreakEmbed::InvalidExtension
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -329,10 +181,8 @@ pub async fn extend(
     let state = match state {
         Some(s) => s,
         None => {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  No active break")
-                .description("There's no break running right now. Start one with `/break start <time>`.")
+            BreakEmbed::NoActiveBreak
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -341,16 +191,13 @@ pub async fn extend(
 
     let new_total = state.total_duration() + extra;
     if new_total > MAX_BREAK_DURATION {
-        CreateEmbed::new()
-            .color(Color::DARK_RED)
-            .title("🚫  Extension would exceed cap")
-            .description(format!(
-                "Total break length would be `{}`, over the {} cap.",
-                humanize_duration(new_total),
-                humanize_duration(MAX_BREAK_DURATION)
-            ))
-            .send_context(ctx, true, Some(15))
-            .await?;
+        BreakEmbed::ExceedsCap {
+            new_total,
+            cap: MAX_BREAK_DURATION,
+        }
+        .to_embed()
+        .send_context(ctx, true, Some(15))
+        .await?;
         return Ok(());
     }
 
@@ -359,142 +206,16 @@ pub async fn extend(
         *ext += extra;
     }
 
-    let new_end = state.ends_at_wall();
-    CreateEmbed::new()
-        .color(Color::DARK_GREEN)
-        .title("⏱️  Break extended")
-        .description(format!(
-            "{} extended the break by **{}**.\n\n\
-             New total: **{}**\n\
-             Ends at: `{}`",
-            ctx.author().mention(),
-            humanize_duration(extra),
-            humanize_duration(state.total_duration()),
-            format_wall_clock(new_end),
-        ))
-        .send_context(ctx, false, None)
-        .await?;
+    let author_mention = ctx.author().mention().to_string();
+    BreakEmbed::Extended {
+        author_mention: &author_mention,
+        extra,
+        total: state.total_duration(),
+        ends_at: state.ends_at_wall(),
+    }
+    .to_embed()
+    .send_context(ctx, false, None)
+    .await?;
 
     Ok(())
-}
-
-/// Parse a break start time: relative duration (`5m`, `1h 30s`) or clock time
-/// (`14:00`). Returns `(duration, clock_label)` — `clock_label` is `Some("17:10")`
-/// when a clock time was supplied, `None` for relative durations.
-fn parse_break_start_time(text: &str) -> Option<(Duration, Option<String>)> {
-    let text = text.trim();
-
-    // Relative duration: 10m, 1h, 30s, 1h 30m, …
-    if let Some(d) = parse_duration_from_string(text) {
-        if d == Duration::ZERO {
-            return None;
-        }
-        return Some((d, None));
-    }
-
-    // Clock time: HH:MM or H:MM — break ends at that wall-clock time.
-    let (h_str, m_str) = text.split_once(':')?;
-    let hour: u8 = h_str.trim().parse().ok()?;
-    let minute: u8 = m_str.trim().parse().ok()?;
-    if hour > 23 || minute > 59 {
-        return None;
-    }
-
-    let now = get_current_time();
-    let now_secs = now.hour() as u64 * 3600 + now.minute() as u64 * 60 + now.second() as u64;
-    let target_secs = hour as u64 * 3600 + minute as u64 * 60;
-
-    let until_secs = if target_secs > now_secs {
-        target_secs - now_secs
-    } else {
-        86400 - now_secs + target_secs
-    };
-
-    if until_secs == 0 {
-        return None;
-    }
-
-    let label = format!("{:02}:{:02}", hour, minute);
-    Some((Duration::from_secs(until_secs), Some(label)))
-}
-
-/// Parse a relative-only break extension: `5m`, `1h 30s`, `90s`, etc.
-/// Clock times are intentionally not supported here — an extension must be an
-/// amount of additional time, not an absolute end time.
-fn parse_break_duration(text: &str) -> Option<Duration> {
-    let d = parse_duration_from_string(text.trim())?;
-    if d == Duration::ZERO {
-        return None;
-    }
-    Some(d)
-}
-
-fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {
-    vec![CreateActionRow::Buttons(vec![
-        CreateButton::new(BTN_BREAK_SKIP)
-            .label("Skip to gathering")
-            .style(ButtonStyle::Primary)
-            .disabled(disabled),
-        CreateButton::new(BTN_BREAK_CANCEL)
-            .label("Cancel")
-            .style(ButtonStyle::Danger)
-            .disabled(disabled),
-    ])]
-}
-
-fn build_break_embed(state: &BreakState, footer: Option<&str>) -> CreateEmbed {
-    let now = Instant::now();
-    let ends_at = state.ends_at_instant();
-    let total = state.total_duration();
-    let remaining = ends_at.saturating_duration_since(now);
-    let extension = state.extension_total();
-
-    let color = if footer.is_some() {
-        Color::DARK_GREEN
-    } else {
-        Color::DARK_GOLD
-    };
-
-    let opening = match &state.clock_time_label {
-        Some(label) => format!("{} started a break until **{}**.", state.author_mention, label),
-        None => format!(
-            "{} started a break of **{}**.",
-            state.author_mention,
-            humanize_duration(state.original_duration)
-        ),
-    };
-
-    let mut description = format!(
-        "{}\n\nTime remaining: **{}**",
-        opening,
-        humanize_duration(remaining),
-    );
-
-    if extension > Duration::ZERO {
-        description.push_str(&format!(
-            "\nExtended by: **{}** (total **{}**)",
-            humanize_duration(extension),
-            humanize_duration(total),
-        ));
-    }
-
-    description.push_str(
-        "\n\nWhen the timer ends, everyone still in voice will be gathered automatically
-        \n— late arrivals will be tracked.",
-    );
-
-    let mut builder = CreateEmbed::new()
-        .color(color)
-        .title("⏸️  Break in progress")
-        .description(description);
-
-    if let Some(text) = footer {
-        builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
-    }
-
-    builder
-}
-
-fn format_wall_clock(t: OffsetDateTime) -> String {
-    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
 }

--- a/src/commands/utility/cmd_gather.rs
+++ b/src/commands/utility/cmd_gather.rs
@@ -1,11 +1,12 @@
 use crate::bot::{Context, MusicBotError};
 use crate::checks::channel_checks::check_author_in_voice_channel;
 use crate::embeds::bot_embeds::BotEmbed;
-use crate::embeds::gather_embed::{humanize_duration, GatherEmbed};
+use crate::embeds::gather_embed::GatherEmbed;
 use crate::player::notifier::{get_current_time, parse_duration_from_string};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
 use crate::service::gather_service::{self, GatherState, PREGATHER_DURATION};
+use crate::service::utils_service::humanize_duration;
 use serenity::all::{
     ChannelId, CreateInteractionResponse, CreateInteractionResponseMessage, GuildId, Mentionable,
     User,

--- a/src/commands/utility/cmd_gather.rs
+++ b/src/commands/utility/cmd_gather.rs
@@ -1,13 +1,14 @@
 use crate::bot::{Context, MusicBotError};
 use crate::checks::channel_checks::check_author_in_voice_channel;
 use crate::embeds::bot_embeds::BotEmbed;
+use crate::embeds::gather_embed::{humanize_duration, GatherEmbed};
 use crate::player::notifier::{get_current_time, parse_duration_from_string};
 use crate::service::channel_service;
 use crate::service::embed_service::SendEmbed;
-use crate::service::gather_service::{self, humanize_duration, GatherState, PREGATHER_DURATION};
+use crate::service::gather_service::{self, GatherState, PREGATHER_DURATION};
 use serenity::all::{
-    ChannelId, Color, CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage,
-    GuildId, Mentionable, User,
+    ChannelId, CreateInteractionResponse, CreateInteractionResponseMessage, GuildId, Mentionable,
+    User,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,13 +49,8 @@ pub async fn start(
         Some(ref t) => match parse_pregather_time(t.trim()) {
             Some(pair) => pair,
             None => {
-                CreateEmbed::new()
-                    .color(Color::DARK_RED)
-                    .title("🚫  Invalid time")
-                    .description(
-                        "Use a relative duration like `10m` or `1h 30m`, \
-                         or a clock time like `10:00` or `14:30`.",
-                    )
+                GatherEmbed::InvalidPregatherTime
+                    .to_embed()
                     .send_context(ctx, true, Some(15))
                     .await?;
                 return Ok(());
@@ -66,10 +62,8 @@ pub async fn start(
     {
         let gatherings = ctx.data().gatherings.read().await;
         if gatherings.contains_key(&guild_id) {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  Gathering already running")
-                .description("There's already an active gathering in this guild.")
+            GatherEmbed::AlreadyRunning
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -138,12 +132,8 @@ pub async fn expect(
     let state = match state {
         Some(s) => s,
         None => {
-            CreateEmbed::new()
-                .color(Color::DARK_RED)
-                .title("🚫  No active gathering")
-                .description(
-                    "There's no gathering running right now. Start one with `/gather start`.",
-                )
+            GatherEmbed::NoActiveGathering
+                .to_embed()
                 .send_context(ctx, true, Some(15))
                 .await?;
             return Ok(());
@@ -174,10 +164,8 @@ pub async fn expect(
         .collect::<Vec<_>>()
         .join(", ");
 
-    CreateEmbed::new()
-        .color(Color::DARK_GREEN)
-        .title("✅  Users expected")
-        .description(format!("{} added to the gathering.", names))
+    GatherEmbed::UsersExpected { names: &names }
+        .to_embed()
         .send_context(ctx, true, Some(15))
         .await?;
 

--- a/src/embeds/break_embed.rs
+++ b/src/embeds/break_embed.rs
@@ -1,4 +1,4 @@
-use crate::embeds::gather_embed::{format_wall_clock, humanize_duration};
+use crate::service::utils_service::{format_wall_clock, humanize_duration};
 use serenity::all::{
     ButtonStyle, Color, CreateActionRow, CreateButton, CreateEmbed, CreateEmbedFooter,
 };

--- a/src/embeds/break_embed.rs
+++ b/src/embeds/break_embed.rs
@@ -1,0 +1,165 @@
+use crate::embeds::gather_embed::{format_wall_clock, humanize_duration};
+use serenity::all::{
+    ButtonStyle, Color, CreateActionRow, CreateButton, CreateEmbed, CreateEmbedFooter,
+};
+use std::time::Duration;
+use time::OffsetDateTime;
+
+pub const BTN_BREAK_CANCEL: &str = "break_cancel";
+pub const BTN_BREAK_SKIP: &str = "break_skip";
+
+pub enum BreakEmbed<'a> {
+    TooLong {
+        max: Duration,
+    },
+    InvalidDuration,
+    AlreadyRunning,
+    InvalidExtension,
+    NoActiveBreak,
+    ExceedsCap {
+        new_total: Duration,
+        cap: Duration,
+    },
+    Extended {
+        author_mention: &'a str,
+        extra: Duration,
+        total: Duration,
+        ends_at: OffsetDateTime,
+    },
+    Progress {
+        author_mention: &'a str,
+        clock_time_label: Option<&'a str>,
+        original_duration: Duration,
+        remaining: Duration,
+        extension: Duration,
+        total: Duration,
+        footer: Option<&'a str>,
+    },
+}
+
+impl<'a> BreakEmbed<'a> {
+    pub fn to_embed(&self) -> CreateEmbed {
+        match self {
+            BreakEmbed::TooLong { max } => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Break too long")
+                .description(format!(
+                    "Maximum break length is {}.",
+                    humanize_duration(*max)
+                )),
+            BreakEmbed::InvalidDuration => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Invalid break duration")
+                .description(
+                    "Use a relative duration like `5m`, `1h 30s`, or `90s`, \
+                     or a clock time like `10:00` or `14:30`.",
+                ),
+            BreakEmbed::AlreadyRunning => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Break already running")
+                .description(
+                    "There's already an active break in this guild — extend it with \
+                     `/break extend <time>` instead.",
+                ),
+            BreakEmbed::InvalidExtension => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Invalid extension")
+                .description("Use a relative duration like `5m`, `1h 30s`, or `90s`."),
+            BreakEmbed::NoActiveBreak => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  No active break")
+                .description(
+                    "There's no break running right now. Start one with `/break start <time>`.",
+                ),
+            BreakEmbed::ExceedsCap { new_total, cap } => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Extension would exceed cap")
+                .description(format!(
+                    "Total break length would be `{}`, over the {} cap.",
+                    humanize_duration(*new_total),
+                    humanize_duration(*cap),
+                )),
+            BreakEmbed::Extended {
+                author_mention,
+                extra,
+                total,
+                ends_at,
+            } => CreateEmbed::new()
+                .color(Color::DARK_GREEN)
+                .title("⏱️  Break extended")
+                .description(format!(
+                    "{} extended the break by **{}**.\n\n\
+                     New total: **{}**\n\
+                     Ends at: `{}`",
+                    author_mention,
+                    humanize_duration(*extra),
+                    humanize_duration(*total),
+                    format_wall_clock(*ends_at),
+                )),
+            BreakEmbed::Progress {
+                author_mention,
+                clock_time_label,
+                original_duration,
+                remaining,
+                extension,
+                total,
+                footer,
+            } => {
+                let color = if footer.is_some() {
+                    Color::DARK_GREEN
+                } else {
+                    Color::DARK_GOLD
+                };
+
+                let opening = match clock_time_label {
+                    Some(label) => format!("{} started a break until **{}**.", author_mention, label),
+                    None => format!(
+                        "{} started a break of **{}**.",
+                        author_mention,
+                        humanize_duration(*original_duration)
+                    ),
+                };
+
+                let mut description =
+                    format!("{}\n\nTime remaining: **{}**", opening, humanize_duration(*remaining));
+
+                if *extension > Duration::ZERO {
+                    description.push_str(&format!(
+                        "\nExtended by: **{}** (total **{}**)",
+                        humanize_duration(*extension),
+                        humanize_duration(*total),
+                    ));
+                }
+
+                description.push_str(
+                    "\n\nWhen the timer ends, everyone still in voice will be gathered automatically
+                    \n— late arrivals will be tracked.",
+                );
+
+                let mut builder = CreateEmbed::new()
+                    .color(color)
+                    .title("⏸️  Break in progress")
+                    .description(description);
+
+                if let Some(text) = footer {
+                    builder = builder.footer(CreateEmbedFooter::new(*text));
+                }
+
+                builder
+            }
+        }
+    }
+}
+
+pub fn break_buttons(disabled: bool) -> Vec<CreateActionRow> {
+    vec![CreateActionRow::Buttons(vec![
+        CreateButton::new(BTN_BREAK_SKIP)
+            .label("Skip to gathering")
+            .style(ButtonStyle::Primary)
+            .disabled(disabled),
+        CreateButton::new(BTN_BREAK_CANCEL)
+            .label("Cancel")
+            .style(ButtonStyle::Danger)
+            .disabled(disabled),
+    ])]
+}

--- a/src/embeds/gather_embed.rs
+++ b/src/embeds/gather_embed.rs
@@ -1,0 +1,307 @@
+use serenity::all::{
+    ButtonStyle, Color, CreateActionRow, CreateButton, CreateEmbed, CreateEmbedFooter,
+};
+use std::time::{Duration, Instant};
+use time::OffsetDateTime;
+
+pub const BTN_HERE: &str = "gather_im_here";
+pub const BTN_CANCEL: &str = "gather_cancel";
+pub const BTN_FORCE_START: &str = "gather_force_start";
+pub const BTN_TOGGLE_SILENT: &str = "gather_toggle_silent";
+
+pub const GRACE_PERIOD: Duration = Duration::from_secs(60);
+pub const MAX_NAME_LEN: usize = 21;
+
+/// One row in the gathering check-in table — already resolved to a display
+/// name so the embed module never has to touch the serenity cache.
+pub struct CheckInRow {
+    pub display_name: String,
+    /// `None` = not arrived, `Some(ZERO)` = on time, `Some(d>0)` = late by `d`.
+    pub arrived: Option<Duration>,
+}
+
+pub enum GatherEmbed<'a> {
+    InvalidPregatherTime,
+    AlreadyRunning,
+    NoActiveGathering,
+    UsersExpected {
+        names: &'a str,
+    },
+    Pregather {
+        ends_at: Instant,
+        ends_at_wall: OffsetDateTime,
+        author_mention: &'a str,
+        schedule_label: &'a str,
+        footer: Option<&'a str>,
+    },
+    CheckIn {
+        rows: &'a [CheckInRow],
+        started_at: Instant,
+        grace_ends_at: Instant,
+        silent: bool,
+        footer: Option<&'a str>,
+    },
+}
+
+impl<'a> GatherEmbed<'a> {
+    pub fn to_embed(&self) -> CreateEmbed {
+        match self {
+            GatherEmbed::InvalidPregatherTime => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Invalid time")
+                .description(
+                    "Use a relative duration like `10m` or `1h 30m`, \
+                     or a clock time like `10:00` or `14:30`.",
+                ),
+            GatherEmbed::AlreadyRunning => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  Gathering already running")
+                .description("There's already an active gathering in this guild."),
+            GatherEmbed::NoActiveGathering => CreateEmbed::new()
+                .color(Color::DARK_RED)
+                .title("🚫  No active gathering")
+                .description(
+                    "There's no gathering running right now. Start one with `/gather start`.",
+                ),
+            GatherEmbed::UsersExpected { names } => CreateEmbed::new()
+                .color(Color::DARK_GREEN)
+                .title("✅  Users expected")
+                .description(format!("{} added to the gathering.", names)),
+            GatherEmbed::Pregather {
+                ends_at,
+                ends_at_wall,
+                author_mention,
+                schedule_label,
+                footer,
+            } => {
+                let remaining = ends_at.saturating_duration_since(Instant::now());
+                let mut builder = CreateEmbed::new()
+                    .color(Color::DARK_BLUE)
+                    .title("📣  Voice Channel Gathering")
+                    .description(format!(
+                        "{} scheduled gathering {}.
+                        \n\nTime remaining: **{}**
+                        \nStarts at: `{}`
+                        \n\nWhen the timer ends, everyone still in voice will be gathered automatically
+                        \n— late arrivals will be tracked.",
+                        author_mention,
+                        schedule_label,
+                        humanize_duration(remaining),
+                        format_wall_clock(*ends_at_wall),
+                    ));
+                if let Some(text) = footer {
+                    builder = builder.footer(CreateEmbedFooter::new(*text));
+                }
+                builder
+            }
+            GatherEmbed::CheckIn {
+                rows,
+                started_at,
+                grace_ends_at,
+                silent,
+                footer,
+            } => build_check_in_embed(rows, *started_at, *grace_ends_at, *silent, *footer),
+        }
+    }
+}
+
+fn build_check_in_embed(
+    rows: &[CheckInRow],
+    started_at: Instant,
+    grace_ends_at: Instant,
+    silent: bool,
+    footer: Option<&str>,
+) -> CreateEmbed {
+    let now = Instant::now();
+    let in_grace = now < grace_ends_at;
+    let grace_remaining = grace_ends_at.saturating_duration_since(now);
+
+    // Sort: arrived first by lateness ascending; missing alphabetically.
+    let mut sorted: Vec<&CheckInRow> = rows.iter().collect();
+    sorted.sort_by(|a, b| match (a.arrived, b.arrived) {
+        (Some(da), Some(db)) => da
+            .cmp(&db)
+            .then_with(|| a.display_name.cmp(&b.display_name)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.display_name.cmp(&b.display_name),
+    });
+
+    let cells: Vec<(String, String)> = sorted
+        .iter()
+        .map(|row| {
+            let status = match row.arrived {
+                Some(d) if d.is_zero() => "ON TIME".to_string(),
+                Some(d) => format!("+{}", format_mmss(d)),
+                None => "--:--".to_string(),
+            };
+            (row.display_name.clone(), status)
+        })
+        .collect();
+
+    let name_width = cells
+        .iter()
+        .map(|(n, _)| n.chars().count())
+        .max()
+        .unwrap_or(4)
+        .clamp(4, MAX_NAME_LEN);
+    let status_width = cells
+        .iter()
+        .map(|(_, s)| s.chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+
+    let sep = format!(
+        "+{}+{}+\n",
+        "-".repeat(name_width + 2),
+        "-".repeat(status_width + 2)
+    );
+    let mut table = String::new();
+    table.push_str(&sep);
+    table.push_str(&format!(
+        "| {:<nw$} | {:<sw$} |\n",
+        "User",
+        "Arrived",
+        nw = name_width,
+        sw = status_width
+    ));
+    table.push_str(&sep);
+    for (name, status) in &cells {
+        let trimmed: String = name.chars().take(name_width).collect();
+        table.push_str(&format!(
+            "| {:<nw$} | {:<sw$} |\n",
+            trimmed,
+            status,
+            nw = name_width,
+            sw = status_width
+        ));
+    }
+    table.push_str(&sep);
+
+    let elapsed = now.saturating_duration_since(started_at);
+    let header = if in_grace {
+        format!(
+            "Grace period: **{}** remaining (counting starts at {}).",
+            format_mmss(grace_remaining),
+            format_mmss(GRACE_PERIOD)
+        )
+    } else {
+        format!(
+            "Counting since gather started — elapsed: **{}**.\nLate arrivals are stamped with their time-from-start.",
+            format_mmss(elapsed)
+        )
+    };
+
+    let present = cells.iter().filter(|(_, s)| s != "--:--").count();
+    let total = cells.len();
+    let ping_status = if silent { "🔕 off" } else { "🔔 on" };
+
+    let color = if footer.is_some() {
+        Color::DARK_GREEN
+    } else if in_grace {
+        Color::DARK_BLUE
+    } else {
+        Color::ORANGE
+    };
+
+    let mut builder = CreateEmbed::new()
+        .color(color)
+        .title("📣  Voice Channel Gathering")
+        .description(format!(
+            "{}\n\nGhost pings: {}\nAttendance: **{}/{}**\n```\n{}```",
+            header, ping_status, present, total, table
+        ));
+
+    if let Some(text) = footer {
+        builder = builder.footer(CreateEmbedFooter::new(text));
+    }
+
+    builder
+}
+
+pub fn pregather_buttons(disabled: bool) -> Vec<CreateActionRow> {
+    vec![CreateActionRow::Buttons(vec![
+        CreateButton::new(BTN_FORCE_START)
+            .label("Start now")
+            .style(ButtonStyle::Primary)
+            .disabled(disabled),
+        CreateButton::new(BTN_CANCEL)
+            .label("Cancel")
+            .style(ButtonStyle::Danger)
+            .disabled(disabled),
+    ])]
+}
+
+pub fn gather_buttons(disabled: bool, silent: bool) -> Vec<CreateActionRow> {
+    vec![CreateActionRow::Buttons(vec![
+        CreateButton::new(BTN_HERE)
+            .label("I'm here!")
+            .style(ButtonStyle::Success)
+            .disabled(disabled),
+        CreateButton::new(BTN_FORCE_START)
+            .label("Force start")
+            .style(ButtonStyle::Primary)
+            .disabled(disabled),
+        CreateButton::new(BTN_TOGGLE_SILENT)
+            .label(if silent { "🔔 Unmute pings" } else { "🔕 Mute pings" })
+            .style(ButtonStyle::Secondary)
+            .disabled(disabled),
+        CreateButton::new(BTN_CANCEL)
+            .label("Cancel")
+            .style(ButtonStyle::Danger)
+            .disabled(disabled),
+    ])]
+}
+
+pub fn humanize_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    if total == 0 {
+        return "0 seconds".to_string();
+    }
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    let mut parts: Vec<String> = Vec::new();
+    if h > 0 {
+        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
+    }
+    if m > 0 {
+        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
+    }
+    if s > 0 {
+        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
+    }
+    parts.join(" ")
+}
+
+pub fn format_wall_clock(t: OffsetDateTime) -> String {
+    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
+}
+
+pub fn format_mmss(d: Duration) -> String {
+    let total = d.as_secs();
+    let m = total / 60;
+    let s = total % 60;
+    format!("{:02}:{:02}", m, s)
+}
+
+/// Replace emoji grapheme clusters with their `:shortcode:` then truncate to
+/// `MAX_NAME_LEN` so the table stays aligned in Discord's monospace font.
+pub fn sanitize_name(name: &str) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
+
+    let mut out = String::new();
+    for g in name.graphemes(true) {
+        if let Some(emoji) = emojis::get(g) {
+            let label = emoji.shortcode().unwrap_or(emoji.name());
+            out.push(':');
+            out.push_str(label.trim_matches(':'));
+            out.push(':');
+        } else {
+            out.push_str(g);
+        }
+    }
+
+    out.chars().take(MAX_NAME_LEN).collect()
+}

--- a/src/embeds/gather_embed.rs
+++ b/src/embeds/gather_embed.rs
@@ -1,3 +1,4 @@
+use crate::service::utils_service::{format_mmss, format_wall_clock, humanize_duration, MAX_NAME_LEN};
 use serenity::all::{
     ButtonStyle, Color, CreateActionRow, CreateButton, CreateEmbed, CreateEmbedFooter,
 };
@@ -10,7 +11,6 @@ pub const BTN_FORCE_START: &str = "gather_force_start";
 pub const BTN_TOGGLE_SILENT: &str = "gather_toggle_silent";
 
 pub const GRACE_PERIOD: Duration = Duration::from_secs(60);
-pub const MAX_NAME_LEN: usize = 21;
 
 /// One row in the gathering check-in table — already resolved to a display
 /// name so the embed module never has to touch the serenity cache.
@@ -254,54 +254,3 @@ pub fn gather_buttons(disabled: bool, silent: bool) -> Vec<CreateActionRow> {
     ])]
 }
 
-pub fn humanize_duration(d: Duration) -> String {
-    let total = d.as_secs();
-    if total == 0 {
-        return "0 seconds".to_string();
-    }
-    let h = total / 3600;
-    let m = (total % 3600) / 60;
-    let s = total % 60;
-    let mut parts: Vec<String> = Vec::new();
-    if h > 0 {
-        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
-    }
-    if m > 0 {
-        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
-    }
-    if s > 0 {
-        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
-    }
-    parts.join(" ")
-}
-
-pub fn format_wall_clock(t: OffsetDateTime) -> String {
-    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
-}
-
-pub fn format_mmss(d: Duration) -> String {
-    let total = d.as_secs();
-    let m = total / 60;
-    let s = total % 60;
-    format!("{:02}:{:02}", m, s)
-}
-
-/// Replace emoji grapheme clusters with their `:shortcode:` then truncate to
-/// `MAX_NAME_LEN` so the table stays aligned in Discord's monospace font.
-pub fn sanitize_name(name: &str) -> String {
-    use unicode_segmentation::UnicodeSegmentation;
-
-    let mut out = String::new();
-    for g in name.graphemes(true) {
-        if let Some(emoji) = emojis::get(g) {
-            let label = emoji.shortcode().unwrap_or(emoji.name());
-            out.push(':');
-            out.push_str(label.trim_matches(':'));
-            out.push(':');
-        } else {
-            out.push_str(g);
-        }
-    }
-
-    out.chars().take(MAX_NAME_LEN).collect()
-}

--- a/src/embeds/mod.rs
+++ b/src/embeds/mod.rs
@@ -1,4 +1,6 @@
 pub mod bot_embeds;
+pub mod break_embed;
+pub mod gather_embed;
 pub mod notify_embeds;
 pub mod player_embed;
 pub mod queue_embed;

--- a/src/service/break_service.rs
+++ b/src/service/break_service.rs
@@ -1,0 +1,239 @@
+use crate::bot::MusicBotError;
+use crate::embeds::break_embed::{
+    break_buttons, BreakEmbed, BTN_BREAK_CANCEL, BTN_BREAK_SKIP,
+};
+use crate::player::notifier::{get_current_time, parse_duration_from_string};
+use serenity::all::{
+    ChannelId, CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage,
+    EditMessage, GuildId, Mentionable, Message, UserId,
+};
+use serenity::prelude::Context as SerenityContext;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use time::OffsetDateTime;
+
+pub const MAX_BREAK_DURATION: Duration = Duration::from_secs(60 * 60 * 4);
+const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Shared mutable state for the active break in a guild. Mutated by
+/// `/break extend` and read by the running `/break start` loop.
+pub struct BreakState {
+    pub author_id: UserId,
+    pub started_at_instant: Instant,
+    pub started_at_wall: OffsetDateTime,
+    pub original_duration: Duration,
+    pub extension: Mutex<Duration>,
+    pub author_mention: String,
+    /// Set when the break was started with a clock time (e.g. "17:10") rather
+    /// than a relative duration. Controls the embed wording.
+    pub clock_time_label: Option<String>,
+}
+
+impl BreakState {
+    pub fn total_duration(&self) -> Duration {
+        self.original_duration + *self.extension.lock().unwrap()
+    }
+
+    pub fn ends_at_instant(&self) -> Instant {
+        self.started_at_instant + self.total_duration()
+    }
+
+    pub fn ends_at_wall(&self) -> OffsetDateTime {
+        self.started_at_wall + self.total_duration()
+    }
+
+    pub fn extension_total(&self) -> Duration {
+        *self.extension.lock().unwrap()
+    }
+}
+
+/// Runs the break timer for an existing `BreakState`. Returns `Ok(true)` if the
+/// break was cancelled (so the caller should skip auto-gather), `Ok(false)` if
+/// it ran to completion.
+pub async fn run_break(
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    text_channel_id: ChannelId,
+    voice_channel_id: ChannelId,
+    state: Arc<BreakState>,
+) -> Result<bool, MusicBotError> {
+    let bot_id = serenity_ctx.cache.current_user().id;
+
+    // Ping all voice members in a separate message above the embed.
+    let voice_mentions: String = serenity_ctx
+        .cache
+        .guild(guild_id)
+        .as_ref()
+        .map(|g| {
+            g.voice_states
+                .values()
+                .filter(|vs| vs.channel_id == Some(voice_channel_id) && vs.user_id != bot_id)
+                .map(|vs| vs.user_id.mention().to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+    if !voice_mentions.is_empty() {
+        let _ = text_channel_id
+            .send_message(&serenity_ctx.http, CreateMessage::new().content(voice_mentions))
+            .await;
+    }
+
+    let mut msg: Message = text_channel_id
+        .send_message(
+            &serenity_ctx.http,
+            CreateMessage::new()
+                .embed(progress_embed(&state, None))
+                .components(break_buttons(false)),
+        )
+        .await
+        .map_err(|e| MusicBotError::InternalError(e.to_string()))?;
+
+    let mut cancelled = false;
+    let mut last_edit = Instant::now();
+    let shard = serenity_ctx.shard.clone();
+
+    loop {
+        let now = Instant::now();
+        let ends_at = state.ends_at_instant();
+        if now >= ends_at {
+            break;
+        }
+
+        let remaining = ends_at.saturating_duration_since(now);
+        let wait = remaining.min(MIN_EDIT_INTERVAL);
+
+        let interaction = msg
+            .await_component_interaction(shard.clone())
+            .timeout(wait)
+            .await;
+
+        if let Some(ic) = interaction {
+            match ic.data.custom_id.as_str() {
+                BTN_BREAK_CANCEL | BTN_BREAK_SKIP => {
+                    if ic.user.id != state.author_id {
+                        ic.create_response(
+                            &serenity_ctx.http,
+                            CreateInteractionResponse::Message(
+                                CreateInteractionResponseMessage::new()
+                                    .content("Only the person who started the break can do that.")
+                                    .ephemeral(true),
+                            ),
+                        )
+                        .await
+                        .ok();
+                        continue;
+                    }
+                    ic.create_response(&serenity_ctx.http, CreateInteractionResponse::Acknowledge)
+                        .await
+                        .ok();
+                    if ic.data.custom_id == BTN_BREAK_CANCEL {
+                        cancelled = true;
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        if Instant::now() < last_edit + MIN_EDIT_INTERVAL {
+            continue;
+        }
+        last_edit = Instant::now();
+        let _ = msg
+            .edit(
+                &serenity_ctx.http,
+                EditMessage::new()
+                    .embed(progress_embed(&state, None))
+                    .components(break_buttons(false)),
+            )
+            .await;
+    }
+
+    let footer = if cancelled {
+        "Break cancelled."
+    } else {
+        "Break is over — starting gathering."
+    };
+
+    let _ = msg
+        .edit(
+            &serenity_ctx.http,
+            EditMessage::new()
+                .embed(progress_embed(&state, Some(footer)))
+                .components(Vec::new()),
+        )
+        .await;
+
+    Ok(cancelled)
+}
+
+fn progress_embed(state: &BreakState, footer: Option<&str>) -> serenity::all::CreateEmbed {
+    let now = Instant::now();
+    let ends_at = state.ends_at_instant();
+    let remaining = ends_at.saturating_duration_since(now);
+    let total = state.total_duration();
+    let extension = state.extension_total();
+
+    BreakEmbed::Progress {
+        author_mention: &state.author_mention,
+        clock_time_label: state.clock_time_label.as_deref(),
+        original_duration: state.original_duration,
+        remaining,
+        extension,
+        total,
+        footer,
+    }
+    .to_embed()
+}
+
+/// Parse a break start time: relative duration (`5m`, `1h 30s`) or clock time
+/// (`14:00`). Returns `(duration, clock_label)` — `clock_label` is `Some("17:10")`
+/// when a clock time was supplied, `None` for relative durations.
+pub fn parse_break_start_time(text: &str) -> Option<(Duration, Option<String>)> {
+    let text = text.trim();
+
+    // Relative duration: 10m, 1h, 30s, 1h 30m, …
+    if let Some(d) = parse_duration_from_string(text) {
+        if d == Duration::ZERO {
+            return None;
+        }
+        return Some((d, None));
+    }
+
+    // Clock time: HH:MM or H:MM — break ends at that wall-clock time.
+    let (h_str, m_str) = text.split_once(':')?;
+    let hour: u8 = h_str.trim().parse().ok()?;
+    let minute: u8 = m_str.trim().parse().ok()?;
+    if hour > 23 || minute > 59 {
+        return None;
+    }
+
+    let now = get_current_time();
+    let now_secs = now.hour() as u64 * 3600 + now.minute() as u64 * 60 + now.second() as u64;
+    let target_secs = hour as u64 * 3600 + minute as u64 * 60;
+
+    let until_secs = if target_secs > now_secs {
+        target_secs - now_secs
+    } else {
+        86400 - now_secs + target_secs
+    };
+
+    if until_secs == 0 {
+        return None;
+    }
+
+    let label = format!("{:02}:{:02}", hour, minute);
+    Some((Duration::from_secs(until_secs), Some(label)))
+}
+
+/// Parse a relative-only break extension: `5m`, `1h 30s`, `90s`, etc.
+/// Clock times are intentionally not supported here — an extension must be an
+/// amount of additional time, not an absolute end time.
+pub fn parse_break_duration(text: &str) -> Option<Duration> {
+    let d = parse_duration_from_string(text.trim())?;
+    if d == Duration::ZERO {
+        return None;
+    }
+    Some(d)
+}

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -1,9 +1,13 @@
 use crate::bot::MusicBotError;
+use crate::embeds::gather_embed::{
+    gather_buttons, pregather_buttons, sanitize_name, CheckInRow, GatherEmbed, BTN_CANCEL,
+    BTN_FORCE_START, BTN_HERE, BTN_TOGGLE_SILENT, GRACE_PERIOD,
+};
 use crate::player::notifier::get_current_time;
 use serenity::all::{
-    ButtonStyle, ChannelId, Color, ComponentInteractionCollector, CreateActionRow, CreateButton,
-    CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage,
-    EditMessage, GuildId, Mentionable, Message, UserId,
+    ChannelId, ComponentInteractionCollector, CreateInteractionResponse,
+    CreateInteractionResponseMessage, CreateMessage, EditMessage, GuildId, Mentionable, Message,
+    UserId,
 };
 use serenity::futures::StreamExt;
 use serenity::http::Http;
@@ -11,7 +15,6 @@ use serenity::prelude::Context as SerenityContext;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use time::OffsetDateTime;
 
 /// Shared state for an active gathering.
 pub struct GatherState {
@@ -36,20 +39,13 @@ impl GatherState {
     }
 }
 
-const GRACE_PERIOD: Duration = Duration::from_secs(60);
 pub const PREGATHER_DURATION: Duration = Duration::from_secs(60);
 const GHOST_PING_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_GATHER_DURATION: Duration = Duration::from_secs(60 * 30);
 const GHOST_PING_LIFETIME: Duration = Duration::from_millis(700);
 const MIN_EDIT_INTERVAL: Duration = Duration::from_secs(5);
-const MAX_NAME_LEN: usize = 21;
 // Max wait in the select loop — keeps button response latency well within 3 s.
 const LOOP_POLL: Duration = Duration::from_millis(800);
-
-const BTN_HERE: &str = "gather_im_here";
-const BTN_CANCEL: &str = "gather_cancel";
-const BTN_FORCE_START: &str = "gather_force_start";
-const BTN_TOGGLE_SILENT: &str = "gather_toggle_silent";
 
 pub async fn start_gather(
     serenity_ctx: &SerenityContext,
@@ -97,7 +93,16 @@ pub async fn start_gather(
             .send_message(
                 &serenity_ctx.http,
                 CreateMessage::new()
-                    .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, &author_mention, &schedule_label, None))
+                    .embed(
+                        GatherEmbed::Pregather {
+                            ends_at: pregather_ends_at,
+                            ends_at_wall: pregather_ends_at_wall,
+                            author_mention: &author_mention,
+                            schedule_label: &schedule_label,
+                            footer: None,
+                        }
+                        .to_embed(),
+                    )
                     .components(pregather_buttons(false)),
             )
             .await
@@ -182,7 +187,16 @@ pub async fn start_gather(
                         .edit(
                             &serenity_ctx.http,
                             EditMessage::new()
-                                .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, &author_mention, &schedule_label, None))
+                                .embed(
+                                    GatherEmbed::Pregather {
+                                        ends_at: pregather_ends_at,
+                                        ends_at_wall: pregather_ends_at_wall,
+                                        author_mention: &author_mention,
+                                        schedule_label: &schedule_label,
+                                        footer: None,
+                                    }
+                                    .to_embed(),
+                                )
                                 .components(pregather_buttons(false)),
                         )
                         .await;
@@ -195,7 +209,16 @@ pub async fn start_gather(
                 .edit(
                     &serenity_ctx.http,
                     EditMessage::new()
-                        .embed(build_pregather_embed(pregather_ends_at, pregather_ends_at_wall, &author_mention, &schedule_label, Some("Cancelled.")))
+                        .embed(
+                            GatherEmbed::Pregather {
+                                ends_at: pregather_ends_at,
+                                ends_at_wall: pregather_ends_at_wall,
+                                author_mention: &author_mention,
+                                schedule_label: &schedule_label,
+                                footer: Some("Cancelled."),
+                            }
+                            .to_embed(),
+                        )
                         .components(Vec::new()),
                 )
                 .await;
@@ -249,7 +272,7 @@ pub async fn start_gather(
             &serenity_ctx.http,
             EditMessage::new()
                 .content("")
-                .embed(build_embed(
+                .embed(check_in_embed(
                     serenity_ctx,
                     guild_id,
                     &expected,
@@ -259,7 +282,7 @@ pub async fn start_gather(
                     silent,
                     None,
                 ))
-                .components(buttons(false, silent)),
+                .components(gather_buttons(false, silent)),
         )
         .await;
 
@@ -376,7 +399,7 @@ pub async fn start_gather(
                 .edit(
                     &serenity_ctx.http,
                     EditMessage::new()
-                        .embed(build_embed(
+                        .embed(check_in_embed(
                             serenity_ctx,
                             guild_id,
                             &expected,
@@ -386,7 +409,7 @@ pub async fn start_gather(
                             silent,
                             None,
                         ))
-                        .components(buttons(false, silent)),
+                        .components(gather_buttons(false, silent)),
                 )
                 .await;
         }
@@ -405,7 +428,7 @@ pub async fn start_gather(
         .edit(
             &serenity_ctx.http,
             EditMessage::new()
-                .embed(build_embed(
+                .embed(check_in_embed(
                     serenity_ctx,
                     guild_id,
                     &expected,
@@ -479,7 +502,7 @@ async fn handle_interaction(
                 &serenity_ctx.http,
                 CreateInteractionResponse::UpdateMessage(
                     CreateInteractionResponseMessage::new()
-                        .embed(build_embed(
+                        .embed(check_in_embed(
                             serenity_ctx,
                             guild_id,
                             expected,
@@ -489,7 +512,7 @@ async fn handle_interaction(
                             silent,
                             None,
                         ))
-                        .components(buttons(false, silent)),
+                        .components(gather_buttons(false, silent)),
                 ),
             )
             .await
@@ -519,7 +542,7 @@ async fn handle_interaction(
                 &serenity_ctx.http,
                 CreateInteractionResponse::UpdateMessage(
                     CreateInteractionResponseMessage::new()
-                        .embed(build_embed(
+                        .embed(check_in_embed(
                             serenity_ctx,
                             guild_id,
                             expected,
@@ -529,7 +552,7 @@ async fn handle_interaction(
                             new_silent,
                             None,
                         ))
-                        .components(buttons(false, new_silent)),
+                        .components(gather_buttons(false, new_silent)),
                 ),
             )
             .await
@@ -585,7 +608,7 @@ async fn handle_interaction(
                 &serenity_ctx.http,
                 CreateInteractionResponse::UpdateMessage(
                     CreateInteractionResponseMessage::new()
-                        .embed(build_embed(
+                        .embed(check_in_embed(
                             serenity_ctx,
                             guild_id,
                             expected,
@@ -595,7 +618,7 @@ async fn handle_interaction(
                             silent,
                             None,
                         ))
-                        .components(buttons(false, silent)),
+                        .components(gather_buttons(false, silent)),
                 ),
             )
             .await
@@ -608,6 +631,44 @@ async fn handle_interaction(
                 .ok();
         }
     }
+}
+
+fn check_in_embed(
+    serenity_ctx: &SerenityContext,
+    guild_id: GuildId,
+    expected: &HashSet<UserId>,
+    arrivals: &HashMap<UserId, Duration>,
+    started_at: Instant,
+    grace_ends_at: Instant,
+    silent: bool,
+    footer: Option<&str>,
+) -> serenity::all::CreateEmbed {
+    let rows: Vec<CheckInRow> = {
+        let guild = serenity_ctx.cache.guild(guild_id);
+        expected
+            .iter()
+            .map(|id| {
+                let raw = guild
+                    .as_ref()
+                    .and_then(|g| g.members.get(id))
+                    .map(|m| m.display_name().to_string())
+                    .unwrap_or_else(|| format!("User {}", id.get()));
+                CheckInRow {
+                    display_name: sanitize_name(&raw),
+                    arrived: arrivals.get(id).copied(),
+                }
+            })
+            .collect()
+    };
+
+    GatherEmbed::CheckIn {
+        rows: &rows,
+        started_at,
+        grace_ends_at,
+        silent,
+        footer,
+    }
+    .to_embed()
 }
 
 fn current_voice_members(
@@ -643,263 +704,6 @@ fn user_in_voice(
         .and_then(|g| g.voice_states.get(&user_id))
         .and_then(|vs| vs.channel_id)
         == Some(voice_channel_id)
-}
-
-fn pregather_buttons(disabled: bool) -> Vec<CreateActionRow> {
-    vec![CreateActionRow::Buttons(vec![
-        CreateButton::new(BTN_FORCE_START)
-            .label("Start now")
-            .style(ButtonStyle::Primary)
-            .disabled(disabled),
-        CreateButton::new(BTN_CANCEL)
-            .label("Cancel")
-            .style(ButtonStyle::Danger)
-            .disabled(disabled),
-    ])]
-}
-
-fn build_pregather_embed(
-    ends_at: Instant,
-    ends_at_wall: OffsetDateTime,
-    author_mention: &str,
-    schedule_label: &str,
-    footer: Option<&str>,
-) -> CreateEmbed {
-    let remaining = ends_at.saturating_duration_since(Instant::now());
-    let mut builder = CreateEmbed::new()
-        .color(Color::DARK_BLUE)
-        .title("📣  Voice Channel Gathering")
-        .description(format!(
-            "{} scheduled gathering {}.
-            \n\nTime remaining: **{}**
-            \nStarts at: `{}`
-            \n\nWhen the timer ends, everyone still in voice will be gathered automatically 
-            \n— late arrivals will be tracked.",
-            author_mention,
-            schedule_label,
-            humanize_duration(remaining),
-            format_wall_clock(ends_at_wall),
-        ));
-    if let Some(text) = footer {
-        builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
-    }
-    builder
-}
-
-pub fn humanize_duration(d: Duration) -> String {
-    let total = d.as_secs();
-    if total == 0 {
-        return "0 seconds".to_string();
-    }
-    let h = total / 3600;
-    let m = (total % 3600) / 60;
-    let s = total % 60;
-    let mut parts: Vec<String> = Vec::new();
-    if h > 0 {
-        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
-    }
-    if m > 0 {
-        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
-    }
-    if s > 0 {
-        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
-    }
-    parts.join(" ")
-}
-
-fn format_wall_clock(t: OffsetDateTime) -> String {
-    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
-}
-
-fn buttons(disabled: bool, silent: bool) -> Vec<CreateActionRow> {
-    vec![CreateActionRow::Buttons(vec![
-        CreateButton::new(BTN_HERE)
-            .label("I'm here!")
-            .style(ButtonStyle::Success)
-            .disabled(disabled),
-        CreateButton::new(BTN_FORCE_START)
-            .label("Force start")
-            .style(ButtonStyle::Primary)
-            .disabled(disabled),
-        CreateButton::new(BTN_TOGGLE_SILENT)
-            .label(if silent { "🔔 Unmute pings" } else { "🔕 Mute pings" })
-            .style(ButtonStyle::Secondary)
-            .disabled(disabled),
-        CreateButton::new(BTN_CANCEL)
-            .label("Cancel")
-            .style(ButtonStyle::Danger)
-            .disabled(disabled),
-    ])]
-}
-
-fn build_embed(
-    serenity_ctx: &SerenityContext,
-    guild_id: GuildId,
-    expected: &HashSet<UserId>,
-    arrivals: &HashMap<UserId, Duration>,
-    started_at: Instant,
-    grace_ends_at: Instant,
-    silent: bool,
-    footer: Option<&str>,
-) -> CreateEmbed {
-    let now = Instant::now();
-    let in_grace = now < grace_ends_at;
-    let grace_remaining = grace_ends_at.saturating_duration_since(now);
-
-    let names: HashMap<UserId, String> = {
-        let guild = serenity_ctx.cache.guild(guild_id);
-        expected
-            .iter()
-            .map(|id| {
-                let raw = guild
-                    .as_ref()
-                    .and_then(|g| g.members.get(id))
-                    .map(|m| m.display_name().to_string())
-                    .unwrap_or_else(|| format!("User {}", id.get()));
-                (*id, sanitize_name(&raw))
-            })
-            .collect()
-    };
-
-    let mut rows: Vec<(String, String)> = expected
-        .iter()
-        .map(|id| {
-            let name = names.get(id).cloned().unwrap_or_default();
-            let status = match arrivals.get(id) {
-                Some(d) if d.is_zero() => "ON TIME".to_string(),
-                Some(d) => format!("+{}", format_mmss(*d)),
-                None => "--:--".to_string(),
-            };
-            (name, status)
-        })
-        .collect();
-
-    rows.sort_by(|a, b| {
-        let aa = arrivals_order(arrivals, a, &names);
-        let bb = arrivals_order(arrivals, b, &names);
-        aa.cmp(&bb)
-    });
-
-    let name_width = rows
-        .iter()
-        .map(|(n, _)| n.chars().count())
-        .max()
-        .unwrap_or(4)
-        .clamp(4, MAX_NAME_LEN);
-    let status_width = rows
-        .iter()
-        .map(|(_, s)| s.chars().count())
-        .max()
-        .unwrap_or(7)
-        .max(7);
-
-    let mut table = String::new();
-    let sep = format!(
-        "+{}+{}+\n",
-        "-".repeat(name_width + 2),
-        "-".repeat(status_width + 2)
-    );
-    table.push_str(&sep);
-    table.push_str(&format!(
-        "| {:<nw$} | {:<sw$} |\n",
-        "User",
-        "Arrived",
-        nw = name_width,
-        sw = status_width
-    ));
-    table.push_str(&sep);
-    for (name, status) in &rows {
-        let trimmed: String = name.chars().take(name_width).collect();
-        table.push_str(&format!(
-            "| {:<nw$} | {:<sw$} |\n",
-            trimmed,
-            status,
-            nw = name_width,
-            sw = status_width
-        ));
-    }
-    table.push_str(&sep);
-
-    let elapsed = now.saturating_duration_since(started_at);
-    let header = if in_grace {
-        format!(
-            "Grace period: **{}** remaining (counting starts at {}).",
-            format_mmss(grace_remaining),
-            format_mmss(GRACE_PERIOD)
-        )
-    } else {
-        format!(
-            "Counting since gather started — elapsed: **{}**.\nLate arrivals are stamped with their time-from-start.",
-            format_mmss(elapsed)
-        )
-    };
-
-    let present = arrivals.len();
-    let total = expected.len();
-    let ping_status = if silent { "🔕 off" } else { "🔔 on" };
-
-    let color = if footer.is_some() {
-        Color::DARK_GREEN
-    } else if in_grace {
-        Color::DARK_BLUE
-    } else {
-        Color::ORANGE
-    };
-
-    let mut builder = CreateEmbed::new()
-        .color(color)
-        .title("📣  Voice Channel Gathering")
-        .description(format!(
-            "{}\n\nGhost pings: {}\nAttendance: **{}/{}**\n```\n{}```",
-            header, ping_status, present, total, table
-        ));
-
-    if let Some(text) = footer {
-        builder = builder.footer(serenity::all::CreateEmbedFooter::new(text));
-    }
-
-    builder
-}
-
-fn arrivals_order(
-    arrivals: &HashMap<UserId, Duration>,
-    row: &(String, String),
-    names: &HashMap<UserId, String>,
-) -> (u8, u128, String) {
-    let id_for_name = names
-        .iter()
-        .find_map(|(id, n)| if n == &row.0 { Some(*id) } else { None });
-    match id_for_name.and_then(|id| arrivals.get(&id)) {
-        Some(d) => (0, d.as_millis(), row.0.clone()),
-        None => (1, 0, row.0.clone()),
-    }
-}
-
-fn format_mmss(d: Duration) -> String {
-    let total = d.as_secs();
-    let m = total / 60;
-    let s = total % 60;
-    format!("{:02}:{:02}", m, s)
-}
-
-/// Replace emoji grapheme clusters with their `:shortcode:` then truncate
-/// to MAX_NAME_LEN so the table stays aligned in Discord's monospace font.
-fn sanitize_name(name: &str) -> String {
-    use unicode_segmentation::UnicodeSegmentation;
-
-    let mut out = String::new();
-    for g in name.graphemes(true) {
-        if let Some(emoji) = emojis::get(g) {
-            let label = emoji.shortcode().unwrap_or(emoji.name());
-            out.push(':');
-            out.push_str(label.trim_matches(':'));
-            out.push(':');
-        } else {
-            out.push_str(g);
-        }
-    }
-
-    out.chars().take(MAX_NAME_LEN).collect()
 }
 
 async fn ghost_ping(http: Arc<Http>, text_channel_id: ChannelId, users: Vec<UserId>) {

--- a/src/service/gather_service.rs
+++ b/src/service/gather_service.rs
@@ -1,9 +1,10 @@
 use crate::bot::MusicBotError;
 use crate::embeds::gather_embed::{
-    gather_buttons, pregather_buttons, sanitize_name, CheckInRow, GatherEmbed, BTN_CANCEL,
-    BTN_FORCE_START, BTN_HERE, BTN_TOGGLE_SILENT, GRACE_PERIOD,
+    gather_buttons, pregather_buttons, CheckInRow, GatherEmbed, BTN_CANCEL, BTN_FORCE_START,
+    BTN_HERE, BTN_TOGGLE_SILENT, GRACE_PERIOD,
 };
 use crate::player::notifier::get_current_time;
+use crate::service::utils_service::sanitize_name;
 use serenity::all::{
     ChannelId, ComponentInteractionCollector, CreateInteractionResponse,
     CreateInteractionResponseMessage, CreateMessage, EditMessage, GuildId, Mentionable, Message,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,3 +1,4 @@
+pub mod break_service;
 pub mod cache_service;
 pub mod channel_service;
 pub mod embed_service;

--- a/src/service/utils_service.rs
+++ b/src/service/utils_service.rs
@@ -1,3 +1,8 @@
+use std::time::Duration;
+use time::OffsetDateTime;
+
+pub const MAX_NAME_LEN: usize = 21;
+
 pub fn number_to_emoji(number: usize) -> String {
     let emoji_numbers = [
         ":zero:", ":one:", ":two:", ":three:", ":four:", ":five:", ":six:", ":seven:", ":eight:",
@@ -10,4 +15,56 @@ pub fn number_to_emoji(number: usize) -> String {
         .map(|c| emoji_numbers[c.to_digit(10).unwrap() as usize].to_string())
         .collect::<Vec<String>>()
         .join("")
+}
+
+pub fn humanize_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    if total == 0 {
+        return "0 seconds".to_string();
+    }
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    let mut parts: Vec<String> = Vec::new();
+    if h > 0 {
+        parts.push(format!("{} {}", h, if h == 1 { "hour" } else { "hours" }));
+    }
+    if m > 0 {
+        parts.push(format!("{} {}", m, if m == 1 { "minute" } else { "minutes" }));
+    }
+    if s > 0 {
+        parts.push(format!("{} {}", s, if s == 1 { "second" } else { "seconds" }));
+    }
+    parts.join(" ")
+}
+
+pub fn format_wall_clock(t: OffsetDateTime) -> String {
+    format!("{:02}:{:02}:{:02}", t.hour(), t.minute(), t.second())
+}
+
+pub fn format_mmss(d: Duration) -> String {
+    let total = d.as_secs();
+    let m = total / 60;
+    let s = total % 60;
+    format!("{:02}:{:02}", m, s)
+}
+
+/// Replace emoji grapheme clusters with their `:shortcode:` then truncate to
+/// `MAX_NAME_LEN` so embed tables stay aligned in Discord's monospace font.
+pub fn sanitize_name(name: &str) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
+
+    let mut out = String::new();
+    for g in name.graphemes(true) {
+        if let Some(emoji) = emojis::get(g) {
+            let label = emoji.shortcode().unwrap_or(emoji.name());
+            out.push(':');
+            out.push_str(label.trim_matches(':'));
+            out.push(':');
+        } else {
+            out.push_str(g);
+        }
+    }
+
+    out.chars().take(MAX_NAME_LEN).collect()
 }


### PR DESCRIPTION
## Summary
This PR extracts embed building and service logic from command handlers into dedicated, reusable modules. The changes improve code organization, reduce duplication, and make the codebase more maintainable by centralizing UI and business logic.

## Key Changes

- **New `embeds/gather_embed.rs` module**: Consolidates all gather-related embed building into an enum-based `GatherEmbed` type with a `to_embed()` method. Includes button definitions and constants previously scattered across `gather_service.rs`.

- **New `embeds/break_embed.rs` module**: Centralizes break-related embed variants (`TooLong`, `InvalidDuration`, `Progress`, `Extended`, etc.) into a `BreakEmbed` enum with consistent styling and formatting.

- **New `service/break_service.rs` module**: Extracts the break timer loop logic from `cmd_break.rs` into a reusable `run_break()` function. Moves `BreakState` struct and related parsing functions (`parse_break_start_time`, `parse_break_duration`) from the command handler to the service layer.

- **Enhanced `service/utils_service.rs`**: Adds shared utility functions (`humanize_duration`, `format_wall_clock`, `format_mmss`, `sanitize_name`) and constants (`MAX_NAME_LEN`) that were previously duplicated or inline in service modules.

- **Refactored `gather_service.rs`**: Removes embed building functions and button creation logic, replacing them with calls to the new `GatherEmbed` enum. Introduces `check_in_embed()` helper that uses the new `sanitize_name()` utility.

- **Simplified `cmd_break.rs`**: Delegates break execution to `break_service::run_break()`, reducing the command handler to orchestration logic. Uses new `BreakEmbed` variants for error messages and status updates.

- **Simplified `cmd_gather.rs`**: Uses `GatherEmbed` enum for error messages instead of inline `CreateEmbed` construction.

- **Updated module exports**: Added `break_embed` and `gather_embed` to `embeds/mod.rs` and `break_service` to `service/mod.rs`. Updated `bot.rs` to import `BreakState` from the service layer.

## Notable Implementation Details

- Embed variants use lifetime parameters (`'a`) to accept borrowed strings, avoiding unnecessary allocations.
- The `CheckInRow` struct encapsulates display name and arrival status for the check-in table, keeping the embed module independent of serenity's cache.
- Button and constant definitions are co-located with their corresponding embed modules for better discoverability.
- Utility functions in `utils_service.rs` are now the single source of truth for formatting and string manipulation across the codebase.

https://claude.ai/code/session_017B2iSodoRDfP6C65SLsABm